### PR TITLE
0.19.1 bugfixes

### DIFF
--- a/AuroraLoader/FormMain.Designer.cs
+++ b/AuroraLoader/FormMain.Designer.cs
@@ -42,24 +42,23 @@
             this.TrackVolume = new System.Windows.Forms.TrackBar();
             this.CheckMusic = new System.Windows.Forms.CheckBox();
             this.TabGameMods = new System.Windows.Forms.TabPage();
-            this.CheckEnableGameMods = new System.Windows.Forms.CheckBox();
+            this.ListUtilities = new System.Windows.Forms.CheckedListBox();
             this.GroupMods = new System.Windows.Forms.GroupBox();
+            this.CheckEnableGameMods = new System.Windows.Forms.CheckBox();
             this.ListGameMods = new System.Windows.Forms.CheckedListBox();
             this.LabelExeMod = new System.Windows.Forms.Label();
             this.ComboSelectLaunchExe = new System.Windows.Forms.ComboBox();
             this.CheckPower = new System.Windows.Forms.CheckBox();
             this.CheckPublic = new System.Windows.Forms.CheckBox();
             this.CheckApproved = new System.Windows.Forms.CheckBox();
-            this.TabUtilities = new System.Windows.Forms.TabPage();
-            this.ListUtilityMods = new System.Windows.Forms.CheckedListBox();
             this.TabMods = new System.Windows.Forms.TabControl();
             this.TabManageMods = new System.Windows.Forms.TabPage();
             this.ButtonConfigureMod = new System.Windows.Forms.Button();
             this.ListManageMods = new System.Windows.Forms.ListView();
+            this.label1 = new System.Windows.Forms.Label();
             ((System.ComponentModel.ISupportInitialize)(this.TrackVolume)).BeginInit();
             this.TabGameMods.SuspendLayout();
             this.GroupMods.SuspendLayout();
-            this.TabUtilities.SuspendLayout();
             this.TabMods.SuspendLayout();
             this.TabManageMods.SuspendLayout();
             this.SuspendLayout();
@@ -222,21 +221,52 @@
             // TabGameMods
             // 
             this.TabGameMods.BackColor = System.Drawing.SystemColors.Control;
-            this.TabGameMods.Controls.Add(this.CheckEnableGameMods);
+            this.TabGameMods.Controls.Add(this.ListUtilities);
             this.TabGameMods.Controls.Add(this.GroupMods);
             this.TabGameMods.Location = new System.Drawing.Point(4, 38);
             this.TabGameMods.Margin = new System.Windows.Forms.Padding(5, 6, 5, 6);
             this.TabGameMods.Name = "TabGameMods";
             this.TabGameMods.Padding = new System.Windows.Forms.Padding(5, 6, 5, 6);
-            this.TabGameMods.Size = new System.Drawing.Size(770, 1010);
+            this.TabGameMods.Size = new System.Drawing.Size(770, 1046);
             this.TabGameMods.TabIndex = 2;
-            this.TabGameMods.Text = "Game mods";
+            this.TabGameMods.Text = "Apply Mods";
+            // 
+            // ListUtilities
+            // 
+            this.ListUtilities.FormattingEnabled = true;
+            this.ListUtilities.Location = new System.Drawing.Point(5, 700);
+            this.ListUtilities.Margin = new System.Windows.Forms.Padding(5, 6, 5, 6);
+            this.ListUtilities.Name = "ListUtilities";
+            this.ListUtilities.Size = new System.Drawing.Size(765, 324);
+            this.ListUtilities.TabIndex = 17;
+            this.ListUtilities.SelectedIndexChanged += new System.EventHandler(this.ListUtilities_SelectedIndexChanged);
+            // 
+            // GroupMods
+            // 
+            this.GroupMods.AutoSize = true;
+            this.GroupMods.Controls.Add(this.label1);
+            this.GroupMods.Controls.Add(this.CheckEnableGameMods);
+            this.GroupMods.Controls.Add(this.ListGameMods);
+            this.GroupMods.Controls.Add(this.LabelExeMod);
+            this.GroupMods.Controls.Add(this.ComboSelectLaunchExe);
+            this.GroupMods.Controls.Add(this.CheckPower);
+            this.GroupMods.Controls.Add(this.CheckPublic);
+            this.GroupMods.Controls.Add(this.CheckApproved);
+            this.GroupMods.Font = new System.Drawing.Font("Microsoft Sans Serif", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point);
+            this.GroupMods.Location = new System.Drawing.Point(5, 23);
+            this.GroupMods.Margin = new System.Windows.Forms.Padding(5, 6, 5, 6);
+            this.GroupMods.Name = "GroupMods";
+            this.GroupMods.Padding = new System.Windows.Forms.Padding(5, 6, 5, 6);
+            this.GroupMods.Size = new System.Drawing.Size(775, 688);
+            this.GroupMods.TabIndex = 0;
+            this.GroupMods.TabStop = false;
+            this.GroupMods.Text = "Game mods";
             // 
             // CheckEnableGameMods
             // 
             this.CheckEnableGameMods.AutoSize = true;
             this.CheckEnableGameMods.Font = new System.Drawing.Font("Microsoft Sans Serif", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point);
-            this.CheckEnableGameMods.Location = new System.Drawing.Point(38, 31);
+            this.CheckEnableGameMods.Location = new System.Drawing.Point(0, 50);
             this.CheckEnableGameMods.Margin = new System.Windows.Forms.Padding(5, 6, 5, 6);
             this.CheckEnableGameMods.Name = "CheckEnableGameMods";
             this.CheckEnableGameMods.Size = new System.Drawing.Size(248, 33);
@@ -245,43 +275,25 @@
             this.CheckEnableGameMods.UseVisualStyleBackColor = true;
             this.CheckEnableGameMods.CheckedChanged += new System.EventHandler(this.CheckEnableGameMods_CheckChanged);
             // 
-            // GroupMods
-            // 
-            this.GroupMods.Controls.Add(this.ListGameMods);
-            this.GroupMods.Controls.Add(this.LabelExeMod);
-            this.GroupMods.Controls.Add(this.ComboSelectLaunchExe);
-            this.GroupMods.Controls.Add(this.CheckPower);
-            this.GroupMods.Controls.Add(this.CheckPublic);
-            this.GroupMods.Controls.Add(this.CheckApproved);
-            this.GroupMods.Enabled = false;
-            this.GroupMods.Font = new System.Drawing.Font("Microsoft Sans Serif", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point);
-            this.GroupMods.Location = new System.Drawing.Point(35, 92);
-            this.GroupMods.Margin = new System.Windows.Forms.Padding(5, 6, 5, 6);
-            this.GroupMods.Name = "GroupMods";
-            this.GroupMods.Padding = new System.Windows.Forms.Padding(5, 6, 5, 6);
-            this.GroupMods.Size = new System.Drawing.Size(698, 877);
-            this.GroupMods.TabIndex = 0;
-            this.GroupMods.TabStop = false;
-            this.GroupMods.Text = "Game mods";
-            // 
             // ListGameMods
             // 
             this.ListGameMods.FormattingEnabled = true;
-            this.ListGameMods.Location = new System.Drawing.Point(16, 199);
+            this.ListGameMods.Location = new System.Drawing.Point(0, 225);
             this.ListGameMods.Margin = new System.Windows.Forms.Padding(5, 6, 5, 6);
             this.ListGameMods.Name = "ListGameMods";
-            this.ListGameMods.Size = new System.Drawing.Size(669, 580);
+            this.ListGameMods.Size = new System.Drawing.Size(765, 356);
+            this.ListGameMods.Sorted = true;
             this.ListGameMods.TabIndex = 6;
             // 
             // LabelExeMod
             // 
             this.LabelExeMod.AutoSize = true;
-            this.LabelExeMod.Location = new System.Drawing.Point(3, 150);
+            this.LabelExeMod.Location = new System.Drawing.Point(0, 100);
             this.LabelExeMod.Margin = new System.Windows.Forms.Padding(5, 0, 5, 0);
             this.LabelExeMod.Name = "LabelExeMod";
-            this.LabelExeMod.Size = new System.Drawing.Size(114, 29);
+            this.LabelExeMod.Size = new System.Drawing.Size(192, 29);
             this.LabelExeMod.TabIndex = 4;
-            this.LabelExeMod.Text = "Exe mod:";
+            this.LabelExeMod.Text = "Executable mod:";
             // 
             // ComboSelectLaunchExe
             // 
@@ -289,10 +301,10 @@
             this.ComboSelectLaunchExe.FormattingEnabled = true;
             this.ComboSelectLaunchExe.Items.AddRange(new object[] {
             "Base Game"});
-            this.ComboSelectLaunchExe.Location = new System.Drawing.Point(138, 144);
+            this.ComboSelectLaunchExe.Location = new System.Drawing.Point(0, 150);
             this.ComboSelectLaunchExe.Margin = new System.Windows.Forms.Padding(5, 6, 5, 6);
             this.ComboSelectLaunchExe.Name = "ComboSelectLaunchExe";
-            this.ComboSelectLaunchExe.Size = new System.Drawing.Size(299, 37);
+            this.ComboSelectLaunchExe.Size = new System.Drawing.Size(348, 37);
             this.ComboSelectLaunchExe.TabIndex = 3;
             this.ComboSelectLaunchExe.SelectedIndexChanged += new System.EventHandler(this.ComboSelectLaunchExe_SelectedIndexChanged);
             // 
@@ -300,7 +312,7 @@
             // 
             this.CheckPower.AutoSize = true;
             this.CheckPower.Font = new System.Drawing.Font("Microsoft Sans Serif", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point);
-            this.CheckPower.Location = new System.Drawing.Point(450, 67);
+            this.CheckPower.Location = new System.Drawing.Point(526, 150);
             this.CheckPower.Margin = new System.Windows.Forms.Padding(5, 6, 5, 6);
             this.CheckPower.Name = "CheckPower";
             this.CheckPower.Size = new System.Drawing.Size(222, 33);
@@ -313,7 +325,7 @@
             // 
             this.CheckPublic.AutoSize = true;
             this.CheckPublic.Font = new System.Drawing.Font("Microsoft Sans Serif", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point);
-            this.CheckPublic.Location = new System.Drawing.Point(252, 67);
+            this.CheckPublic.Location = new System.Drawing.Point(526, 100);
             this.CheckPublic.Margin = new System.Windows.Forms.Padding(5, 6, 5, 6);
             this.CheckPublic.Name = "CheckPublic";
             this.CheckPublic.Size = new System.Drawing.Size(172, 33);
@@ -328,7 +340,7 @@
             this.CheckApproved.Checked = true;
             this.CheckApproved.CheckState = System.Windows.Forms.CheckState.Checked;
             this.CheckApproved.Font = new System.Drawing.Font("Microsoft Sans Serif", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point);
-            this.CheckApproved.Location = new System.Drawing.Point(10, 67);
+            this.CheckApproved.Location = new System.Drawing.Point(526, 50);
             this.CheckApproved.Margin = new System.Windows.Forms.Padding(5, 6, 5, 6);
             this.CheckApproved.Name = "CheckApproved";
             this.CheckApproved.Size = new System.Drawing.Size(209, 33);
@@ -337,38 +349,17 @@
             this.CheckApproved.UseVisualStyleBackColor = true;
             this.CheckApproved.CheckedChanged += new System.EventHandler(this.CheckApproved_CheckedChanged);
             // 
-            // TabUtilities
-            // 
-            this.TabUtilities.BackColor = System.Drawing.SystemColors.Control;
-            this.TabUtilities.Controls.Add(this.ListUtilityMods);
-            this.TabUtilities.Location = new System.Drawing.Point(4, 38);
-            this.TabUtilities.Margin = new System.Windows.Forms.Padding(5, 6, 5, 6);
-            this.TabUtilities.Name = "TabUtilities";
-            this.TabUtilities.Padding = new System.Windows.Forms.Padding(5, 6, 5, 6);
-            this.TabUtilities.Size = new System.Drawing.Size(770, 1010);
-            this.TabUtilities.TabIndex = 1;
-            this.TabUtilities.Text = "Utilities";
-            // 
-            // ListUtilityMods
-            // 
-            this.ListUtilityMods.FormattingEnabled = true;
-            this.ListUtilityMods.Location = new System.Drawing.Point(10, 473);
-            this.ListUtilityMods.Margin = new System.Windows.Forms.Padding(5, 6, 5, 6);
-            this.ListUtilityMods.Name = "ListUtilityMods";
-            this.ListUtilityMods.Size = new System.Drawing.Size(742, 484);
-            this.ListUtilityMods.TabIndex = 17;
-            // 
             // TabMods
             // 
-            this.TabMods.Controls.Add(this.TabUtilities);
             this.TabMods.Controls.Add(this.TabGameMods);
             this.TabMods.Controls.Add(this.TabManageMods);
+            this.TabMods.Dock = System.Windows.Forms.DockStyle.Right;
             this.TabMods.Font = new System.Drawing.Font("Microsoft Sans Serif", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point);
-            this.TabMods.Location = new System.Drawing.Point(840, 23);
+            this.TabMods.Location = new System.Drawing.Point(857, 0);
             this.TabMods.Margin = new System.Windows.Forms.Padding(5, 6, 5, 6);
             this.TabMods.Name = "TabMods";
             this.TabMods.SelectedIndex = 2;
-            this.TabMods.Size = new System.Drawing.Size(778, 1052);
+            this.TabMods.Size = new System.Drawing.Size(778, 1088);
             this.TabMods.TabIndex = 16;
             this.TabMods.SelectedIndexChanged += new System.EventHandler(this.TabMods_SelectedIndexChanged);
             // 
@@ -380,7 +371,7 @@
             this.TabManageMods.Controls.Add(this.ListManageMods);
             this.TabManageMods.Location = new System.Drawing.Point(4, 38);
             this.TabManageMods.Name = "TabManageMods";
-            this.TabManageMods.Size = new System.Drawing.Size(770, 1010);
+            this.TabManageMods.Size = new System.Drawing.Size(770, 1046);
             this.TabManageMods.TabIndex = 3;
             this.TabManageMods.Text = "Manage Mods";
             // 
@@ -406,6 +397,16 @@
             this.ListManageMods.TabIndex = 0;
             this.ListManageMods.UseCompatibleStateImageBehavior = false;
             this.ListManageMods.SelectedIndexChanged += new System.EventHandler(this.ListManageMods_SelectedIndexChanged);
+            // 
+            // label1
+            // 
+            this.label1.AutoSize = true;
+            this.label1.Location = new System.Drawing.Point(0, 625);
+            this.label1.Margin = new System.Windows.Forms.Padding(5, 0, 5, 0);
+            this.label1.Name = "label1";
+            this.label1.Size = new System.Drawing.Size(98, 29);
+            this.label1.TabIndex = 4;
+            this.label1.Text = "Utilities:";
             // 
             // FormMain
             // 
@@ -435,7 +436,6 @@
             this.TabGameMods.PerformLayout();
             this.GroupMods.ResumeLayout(false);
             this.GroupMods.PerformLayout();
-            this.TabUtilities.ResumeLayout(false);
             this.TabMods.ResumeLayout(false);
             this.TabManageMods.ResumeLayout(false);
             this.ResumeLayout(false);
@@ -466,12 +466,12 @@
         private System.Windows.Forms.CheckBox CheckPublic;
         private System.Windows.Forms.CheckBox CheckApproved;
         private System.Windows.Forms.CheckBox CheckEnableGameMods;
-        private System.Windows.Forms.TabPage TabUtilities;
-        private System.Windows.Forms.CheckedListBox ListUtilityMods;
         private System.Windows.Forms.TabControl TabMods;
         private System.Windows.Forms.TabPage TabManageMods;
         private System.Windows.Forms.ListView ListManageMods;
         private System.Windows.Forms.Button ButtonConfigureMod;
+        private System.Windows.Forms.CheckedListBox ListUtilities;
+        private System.Windows.Forms.Label label1;
     }
 }
 

--- a/AuroraLoader/FormMain.Designer.cs
+++ b/AuroraLoader/FormMain.Designer.cs
@@ -41,11 +41,12 @@
             this.ButtonModBugs = new System.Windows.Forms.Button();
             this.TrackVolume = new System.Windows.Forms.TrackBar();
             this.CheckMusic = new System.Windows.Forms.CheckBox();
-            this.TabGameMods = new System.Windows.Forms.TabPage();
+            this.TabApplyMods = new System.Windows.Forms.TabPage();
             this.ListUtilities = new System.Windows.Forms.CheckedListBox();
             this.GroupMods = new System.Windows.Forms.GroupBox();
+            this.LabelUtilities = new System.Windows.Forms.Label();
             this.CheckEnableGameMods = new System.Windows.Forms.CheckBox();
-            this.ListGameMods = new System.Windows.Forms.CheckedListBox();
+            this.ListDatabaseMods = new System.Windows.Forms.CheckedListBox();
             this.LabelExeMod = new System.Windows.Forms.Label();
             this.ComboSelectLaunchExe = new System.Windows.Forms.ComboBox();
             this.CheckPower = new System.Windows.Forms.CheckBox();
@@ -55,9 +56,9 @@
             this.TabManageMods = new System.Windows.Forms.TabPage();
             this.ButtonConfigureMod = new System.Windows.Forms.Button();
             this.ListManageMods = new System.Windows.Forms.ListView();
-            this.label1 = new System.Windows.Forms.Label();
+            this.LabelDatabaseMods = new System.Windows.Forms.Label();
             ((System.ComponentModel.ISupportInitialize)(this.TrackVolume)).BeginInit();
-            this.TabGameMods.SuspendLayout();
+            this.TabApplyMods.SuspendLayout();
             this.GroupMods.SuspendLayout();
             this.TabMods.SuspendLayout();
             this.TabManageMods.SuspendLayout();
@@ -220,16 +221,16 @@
             // 
             // TabGameMods
             // 
-            this.TabGameMods.BackColor = System.Drawing.SystemColors.Control;
-            this.TabGameMods.Controls.Add(this.ListUtilities);
-            this.TabGameMods.Controls.Add(this.GroupMods);
-            this.TabGameMods.Location = new System.Drawing.Point(4, 38);
-            this.TabGameMods.Margin = new System.Windows.Forms.Padding(5, 6, 5, 6);
-            this.TabGameMods.Name = "TabGameMods";
-            this.TabGameMods.Padding = new System.Windows.Forms.Padding(5, 6, 5, 6);
-            this.TabGameMods.Size = new System.Drawing.Size(770, 1046);
-            this.TabGameMods.TabIndex = 2;
-            this.TabGameMods.Text = "Apply Mods";
+            this.TabApplyMods.BackColor = System.Drawing.SystemColors.Control;
+            this.TabApplyMods.Controls.Add(this.ListUtilities);
+            this.TabApplyMods.Controls.Add(this.GroupMods);
+            this.TabApplyMods.Location = new System.Drawing.Point(4, 38);
+            this.TabApplyMods.Margin = new System.Windows.Forms.Padding(5, 6, 5, 6);
+            this.TabApplyMods.Name = "TabGameMods";
+            this.TabApplyMods.Padding = new System.Windows.Forms.Padding(5, 6, 5, 6);
+            this.TabApplyMods.Size = new System.Drawing.Size(770, 1046);
+            this.TabApplyMods.TabIndex = 2;
+            this.TabApplyMods.Text = "Apply Mods";
             // 
             // ListUtilities
             // 
@@ -244,9 +245,10 @@
             // GroupMods
             // 
             this.GroupMods.AutoSize = true;
-            this.GroupMods.Controls.Add(this.label1);
+            this.GroupMods.Controls.Add(this.LabelDatabaseMods);
+            this.GroupMods.Controls.Add(this.LabelUtilities);
             this.GroupMods.Controls.Add(this.CheckEnableGameMods);
-            this.GroupMods.Controls.Add(this.ListGameMods);
+            this.GroupMods.Controls.Add(this.ListDatabaseMods);
             this.GroupMods.Controls.Add(this.LabelExeMod);
             this.GroupMods.Controls.Add(this.ComboSelectLaunchExe);
             this.GroupMods.Controls.Add(this.CheckPower);
@@ -261,6 +263,16 @@
             this.GroupMods.TabIndex = 0;
             this.GroupMods.TabStop = false;
             this.GroupMods.Text = "Game mods";
+            // 
+            // LabelUtilities
+            // 
+            this.LabelUtilities.AutoSize = true;
+            this.LabelUtilities.Location = new System.Drawing.Point(0, 625);
+            this.LabelUtilities.Margin = new System.Windows.Forms.Padding(5, 0, 5, 0);
+            this.LabelUtilities.Name = "LabelUtilities";
+            this.LabelUtilities.Size = new System.Drawing.Size(98, 29);
+            this.LabelUtilities.TabIndex = 4;
+            this.LabelUtilities.Text = "Utilities:";
             // 
             // CheckEnableGameMods
             // 
@@ -277,13 +289,13 @@
             // 
             // ListGameMods
             // 
-            this.ListGameMods.FormattingEnabled = true;
-            this.ListGameMods.Location = new System.Drawing.Point(0, 225);
-            this.ListGameMods.Margin = new System.Windows.Forms.Padding(5, 6, 5, 6);
-            this.ListGameMods.Name = "ListGameMods";
-            this.ListGameMods.Size = new System.Drawing.Size(765, 356);
-            this.ListGameMods.Sorted = true;
-            this.ListGameMods.TabIndex = 6;
+            this.ListDatabaseMods.FormattingEnabled = true;
+            this.ListDatabaseMods.Location = new System.Drawing.Point(0, 250);
+            this.ListDatabaseMods.Margin = new System.Windows.Forms.Padding(5, 6, 5, 6);
+            this.ListDatabaseMods.Name = "ListGameMods";
+            this.ListDatabaseMods.Size = new System.Drawing.Size(765, 324);
+            this.ListDatabaseMods.Sorted = true;
+            this.ListDatabaseMods.TabIndex = 6;
             // 
             // LabelExeMod
             // 
@@ -351,7 +363,7 @@
             // 
             // TabMods
             // 
-            this.TabMods.Controls.Add(this.TabGameMods);
+            this.TabMods.Controls.Add(this.TabApplyMods);
             this.TabMods.Controls.Add(this.TabManageMods);
             this.TabMods.Dock = System.Windows.Forms.DockStyle.Right;
             this.TabMods.Font = new System.Drawing.Font("Microsoft Sans Serif", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point);
@@ -398,15 +410,15 @@
             this.ListManageMods.UseCompatibleStateImageBehavior = false;
             this.ListManageMods.SelectedIndexChanged += new System.EventHandler(this.ListManageMods_SelectedIndexChanged);
             // 
-            // label1
+            // LabelDatabaseMods
             // 
-            this.label1.AutoSize = true;
-            this.label1.Location = new System.Drawing.Point(0, 625);
-            this.label1.Margin = new System.Windows.Forms.Padding(5, 0, 5, 0);
-            this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(98, 29);
-            this.label1.TabIndex = 4;
-            this.label1.Text = "Utilities:";
+            this.LabelDatabaseMods.AutoSize = true;
+            this.LabelDatabaseMods.Location = new System.Drawing.Point(0, 200);
+            this.LabelDatabaseMods.Margin = new System.Windows.Forms.Padding(5, 0, 5, 0);
+            this.LabelDatabaseMods.Name = "LabelDatabaseMods";
+            this.LabelDatabaseMods.Size = new System.Drawing.Size(187, 29);
+            this.LabelDatabaseMods.TabIndex = 4;
+            this.LabelDatabaseMods.Text = "Database mods:";
             // 
             // FormMain
             // 
@@ -432,8 +444,8 @@
             this.Text = "Aurora Loader";
             this.Load += new System.EventHandler(this.FormMain_Load);
             ((System.ComponentModel.ISupportInitialize)(this.TrackVolume)).EndInit();
-            this.TabGameMods.ResumeLayout(false);
-            this.TabGameMods.PerformLayout();
+            this.TabApplyMods.ResumeLayout(false);
+            this.TabApplyMods.PerformLayout();
             this.GroupMods.ResumeLayout(false);
             this.GroupMods.PerformLayout();
             this.TabMods.ResumeLayout(false);
@@ -457,9 +469,9 @@
         private System.Windows.Forms.Button ButtonModBugs;
         private System.Windows.Forms.TrackBar TrackVolume;
         private System.Windows.Forms.CheckBox CheckMusic;
-        private System.Windows.Forms.TabPage TabGameMods;
+        private System.Windows.Forms.TabPage TabApplyMods;
         private System.Windows.Forms.GroupBox GroupMods;
-        private System.Windows.Forms.CheckedListBox ListGameMods;
+        private System.Windows.Forms.CheckedListBox ListDatabaseMods;
         private System.Windows.Forms.Label LabelExeMod;
         private System.Windows.Forms.ComboBox ComboSelectLaunchExe;
         private System.Windows.Forms.CheckBox CheckPower;
@@ -471,7 +483,8 @@
         private System.Windows.Forms.ListView ListManageMods;
         private System.Windows.Forms.Button ButtonConfigureMod;
         private System.Windows.Forms.CheckedListBox ListUtilities;
-        private System.Windows.Forms.Label label1;
+        private System.Windows.Forms.Label LabelUtilities;
+        private System.Windows.Forms.Label LabelDatabaseMods;
     }
 }
 

--- a/AuroraLoader/FormMain.Designer.cs
+++ b/AuroraLoader/FormMain.Designer.cs
@@ -42,20 +42,19 @@
             this.TrackVolume = new System.Windows.Forms.TrackBar();
             this.CheckMusic = new System.Windows.Forms.CheckBox();
             this.TabGameMods = new System.Windows.Forms.TabPage();
+            this.CheckEnableGameMods = new System.Windows.Forms.CheckBox();
             this.GroupMods = new System.Windows.Forms.GroupBox();
-            this.ButtonConfigureExe = new System.Windows.Forms.Button();
             this.ListGameMods = new System.Windows.Forms.CheckedListBox();
             this.LabelExeMod = new System.Windows.Forms.Label();
             this.ComboSelectLaunchExe = new System.Windows.Forms.ComboBox();
             this.CheckPower = new System.Windows.Forms.CheckBox();
             this.CheckPublic = new System.Windows.Forms.CheckBox();
             this.CheckApproved = new System.Windows.Forms.CheckBox();
-            this.CheckEnableGameMods = new System.Windows.Forms.CheckBox();
             this.TabUtilities = new System.Windows.Forms.TabPage();
-            this.ButtonConfigureUtility = new System.Windows.Forms.Button();
             this.ListUtilityMods = new System.Windows.Forms.CheckedListBox();
             this.TabMods = new System.Windows.Forms.TabControl();
             this.TabManageMods = new System.Windows.Forms.TabPage();
+            this.ButtonConfigureMod = new System.Windows.Forms.Button();
             this.ListManageMods = new System.Windows.Forms.ListView();
             ((System.ComponentModel.ISupportInitialize)(this.TrackVolume)).BeginInit();
             this.TabGameMods.SuspendLayout();
@@ -151,10 +150,10 @@
             // ButtonInstallOrUpdate
             // 
             this.ButtonInstallOrUpdate.Font = new System.Drawing.Font("Microsoft Sans Serif", 14.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point);
-            this.ButtonInstallOrUpdate.Location = new System.Drawing.Point(5, 586);
+            this.ButtonInstallOrUpdate.Location = new System.Drawing.Point(75, 590);
             this.ButtonInstallOrUpdate.Margin = new System.Windows.Forms.Padding(5, 6, 5, 6);
             this.ButtonInstallOrUpdate.Name = "ButtonInstallOrUpdate";
-            this.ButtonInstallOrUpdate.Size = new System.Drawing.Size(373, 88);
+            this.ButtonInstallOrUpdate.Size = new System.Drawing.Size(250, 75);
             this.ButtonInstallOrUpdate.TabIndex = 15;
             this.ButtonInstallOrUpdate.Text = "Install";
             this.ButtonInstallOrUpdate.UseVisualStyleBackColor = true;
@@ -233,9 +232,21 @@
             this.TabGameMods.TabIndex = 2;
             this.TabGameMods.Text = "Game mods";
             // 
+            // CheckEnableGameMods
+            // 
+            this.CheckEnableGameMods.AutoSize = true;
+            this.CheckEnableGameMods.Font = new System.Drawing.Font("Microsoft Sans Serif", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point);
+            this.CheckEnableGameMods.Location = new System.Drawing.Point(38, 31);
+            this.CheckEnableGameMods.Margin = new System.Windows.Forms.Padding(5, 6, 5, 6);
+            this.CheckEnableGameMods.Name = "CheckEnableGameMods";
+            this.CheckEnableGameMods.Size = new System.Drawing.Size(248, 33);
+            this.CheckEnableGameMods.TabIndex = 1;
+            this.CheckEnableGameMods.Text = "Enable game mods";
+            this.CheckEnableGameMods.UseVisualStyleBackColor = true;
+            this.CheckEnableGameMods.CheckedChanged += new System.EventHandler(this.CheckEnableGameMods_CheckChanged);
+            // 
             // GroupMods
             // 
-            this.GroupMods.Controls.Add(this.ButtonConfigureExe);
             this.GroupMods.Controls.Add(this.ListGameMods);
             this.GroupMods.Controls.Add(this.LabelExeMod);
             this.GroupMods.Controls.Add(this.ComboSelectLaunchExe);
@@ -252,18 +263,6 @@
             this.GroupMods.TabIndex = 0;
             this.GroupMods.TabStop = false;
             this.GroupMods.Text = "Game mods";
-            // 
-            // ButtonConfigureExe
-            // 
-            this.ButtonConfigureExe.Font = new System.Drawing.Font("Microsoft Sans Serif", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point);
-            this.ButtonConfigureExe.Location = new System.Drawing.Point(447, 119);
-            this.ButtonConfigureExe.Margin = new System.Windows.Forms.Padding(5, 6, 5, 6);
-            this.ButtonConfigureExe.Name = "ButtonConfigureExe";
-            this.ButtonConfigureExe.Size = new System.Drawing.Size(238, 66);
-            this.ButtonConfigureExe.TabIndex = 15;
-            this.ButtonConfigureExe.Text = "Configure";
-            this.ButtonConfigureExe.UseVisualStyleBackColor = true;
-            this.ButtonConfigureExe.Click += new System.EventHandler(this.ButtonConfigureExe_Click);
             // 
             // ListGameMods
             // 
@@ -338,23 +337,9 @@
             this.CheckApproved.UseVisualStyleBackColor = true;
             this.CheckApproved.CheckedChanged += new System.EventHandler(this.CheckApproved_CheckedChanged);
             // 
-            // CheckEnableGameMods
-            // 
-            this.CheckEnableGameMods.AutoSize = true;
-            this.CheckEnableGameMods.Font = new System.Drawing.Font("Microsoft Sans Serif", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point);
-            this.CheckEnableGameMods.Location = new System.Drawing.Point(38, 31);
-            this.CheckEnableGameMods.Margin = new System.Windows.Forms.Padding(5, 6, 5, 6);
-            this.CheckEnableGameMods.Name = "CheckEnableGameMods";
-            this.CheckEnableGameMods.Size = new System.Drawing.Size(248, 33);
-            this.CheckEnableGameMods.TabIndex = 1;
-            this.CheckEnableGameMods.Text = "Enable game mods";
-            this.CheckEnableGameMods.UseVisualStyleBackColor = true;
-            this.CheckEnableGameMods.CheckedChanged += new System.EventHandler(this.CheckEnableGameMods_CheckChanged);
-            // 
             // TabUtilities
             // 
             this.TabUtilities.BackColor = System.Drawing.SystemColors.Control;
-            this.TabUtilities.Controls.Add(this.ButtonConfigureUtility);
             this.TabUtilities.Controls.Add(this.ListUtilityMods);
             this.TabUtilities.Location = new System.Drawing.Point(4, 38);
             this.TabUtilities.Margin = new System.Windows.Forms.Padding(5, 6, 5, 6);
@@ -364,28 +349,14 @@
             this.TabUtilities.TabIndex = 1;
             this.TabUtilities.Text = "Utilities";
             // 
-            // ButtonConfigureUtility
-            // 
-            this.ButtonConfigureUtility.Enabled = false;
-            this.ButtonConfigureUtility.Font = new System.Drawing.Font("Microsoft Sans Serif", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point);
-            this.ButtonConfigureUtility.Location = new System.Drawing.Point(263, 46);
-            this.ButtonConfigureUtility.Margin = new System.Windows.Forms.Padding(5, 6, 5, 6);
-            this.ButtonConfigureUtility.Name = "ButtonConfigureUtility";
-            this.ButtonConfigureUtility.Size = new System.Drawing.Size(458, 63);
-            this.ButtonConfigureUtility.TabIndex = 17;
-            this.ButtonConfigureUtility.Text = "Configure selected";
-            this.ButtonConfigureUtility.UseVisualStyleBackColor = true;
-            this.ButtonConfigureUtility.Click += new System.EventHandler(this.ButtonConfigureUtility_Click);
-            // 
             // ListUtilityMods
             // 
             this.ListUtilityMods.FormattingEnabled = true;
-            this.ListUtilityMods.Location = new System.Drawing.Point(10, 121);
+            this.ListUtilityMods.Location = new System.Drawing.Point(10, 473);
             this.ListUtilityMods.Margin = new System.Windows.Forms.Padding(5, 6, 5, 6);
             this.ListUtilityMods.Name = "ListUtilityMods";
-            this.ListUtilityMods.Size = new System.Drawing.Size(742, 836);
+            this.ListUtilityMods.Size = new System.Drawing.Size(742, 484);
             this.ListUtilityMods.TabIndex = 17;
-            this.ListUtilityMods.SelectedIndexChanged += new System.EventHandler(this.ListUtilityMods_SelectedIndexChanged);
             // 
             // TabMods
             // 
@@ -396,7 +367,7 @@
             this.TabMods.Location = new System.Drawing.Point(840, 23);
             this.TabMods.Margin = new System.Windows.Forms.Padding(5, 6, 5, 6);
             this.TabMods.Name = "TabMods";
-            this.TabMods.SelectedIndex = 1;
+            this.TabMods.SelectedIndex = 2;
             this.TabMods.Size = new System.Drawing.Size(778, 1052);
             this.TabMods.TabIndex = 16;
             this.TabMods.SelectedIndexChanged += new System.EventHandler(this.TabMods_SelectedIndexChanged);
@@ -404,6 +375,7 @@
             // TabManageMods
             // 
             this.TabManageMods.AutoScroll = true;
+            this.TabManageMods.Controls.Add(this.ButtonConfigureMod);
             this.TabManageMods.Controls.Add(this.ButtonInstallOrUpdate);
             this.TabManageMods.Controls.Add(this.ListManageMods);
             this.TabManageMods.Location = new System.Drawing.Point(4, 38);
@@ -412,10 +384,23 @@
             this.TabManageMods.TabIndex = 3;
             this.TabManageMods.Text = "Manage Mods";
             // 
+            // ButtonConfigureMod
+            // 
+            this.ButtonConfigureMod.Font = new System.Drawing.Font("Microsoft Sans Serif", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point);
+            this.ButtonConfigureMod.Location = new System.Drawing.Point(376, 590);
+            this.ButtonConfigureMod.Margin = new System.Windows.Forms.Padding(5, 6, 5, 6);
+            this.ButtonConfigureMod.Name = "ButtonConfigureMod";
+            this.ButtonConfigureMod.Size = new System.Drawing.Size(250, 75);
+            this.ButtonConfigureMod.TabIndex = 15;
+            this.ButtonConfigureMod.Text = "Configure";
+            this.ButtonConfigureMod.UseVisualStyleBackColor = true;
+            this.ButtonConfigureMod.Click += new System.EventHandler(this.ButtonConfigureMod_Click);
+            // 
             // ListManageMods
             // 
             this.ListManageMods.HideSelection = false;
             this.ListManageMods.Location = new System.Drawing.Point(0, 3);
+            this.ListManageMods.MultiSelect = false;
             this.ListManageMods.Name = "ListManageMods";
             this.ListManageMods.Size = new System.Drawing.Size(767, 574);
             this.ListManageMods.TabIndex = 0;
@@ -474,7 +459,6 @@
         private System.Windows.Forms.CheckBox CheckMusic;
         private System.Windows.Forms.TabPage TabGameMods;
         private System.Windows.Forms.GroupBox GroupMods;
-        private System.Windows.Forms.Button ButtonConfigureExe;
         private System.Windows.Forms.CheckedListBox ListGameMods;
         private System.Windows.Forms.Label LabelExeMod;
         private System.Windows.Forms.ComboBox ComboSelectLaunchExe;
@@ -483,11 +467,11 @@
         private System.Windows.Forms.CheckBox CheckApproved;
         private System.Windows.Forms.CheckBox CheckEnableGameMods;
         private System.Windows.Forms.TabPage TabUtilities;
-        private System.Windows.Forms.Button ButtonConfigureUtility;
         private System.Windows.Forms.CheckedListBox ListUtilityMods;
         private System.Windows.Forms.TabControl TabMods;
         private System.Windows.Forms.TabPage TabManageMods;
         private System.Windows.Forms.ListView ListManageMods;
+        private System.Windows.Forms.Button ButtonConfigureMod;
     }
 }
 

--- a/AuroraLoader/FormMain.cs
+++ b/AuroraLoader/FormMain.cs
@@ -54,11 +54,11 @@ namespace AuroraLoader
             Cursor = Cursors.Default;
             CheckEnableGameMods.Enabled = true;
             ComboSelectLaunchExe.Enabled = false;
-            ListGameMods.Enabled = false;
+            ListDatabaseMods.Enabled = false;
             CheckApproved.Enabled = false;
             CheckPower.Enabled = false;
             CheckPublic.Enabled = false;
-            TabMods.SelectedTab = TabGameMods;
+            TabMods.SelectedTab = TabApplyMods;
         }
 
         private void InstallAurora(string executablePath)
@@ -158,7 +158,7 @@ namespace AuroraLoader
                     ButtonModBugs.ForeColor = Color.OrangeRed;
 
                     ComboSelectLaunchExe.Enabled = true;
-                    ListGameMods.Enabled = true;
+                    ListDatabaseMods.Enabled = true;
                     CheckApproved.Enabled = true;
                     CheckPower.Enabled = true;
                     CheckPublic.Enabled = true;
@@ -179,7 +179,7 @@ namespace AuroraLoader
 
                 CheckEnableGameMods.Enabled = true;
                 ComboSelectLaunchExe.Enabled = false;
-                ListGameMods.Enabled = false;
+                ListDatabaseMods.Enabled = false;
                 CheckApproved.Enabled = false;
                 CheckPower.Enabled = false;
                 CheckPublic.Enabled = false;
@@ -245,8 +245,8 @@ namespace AuroraLoader
         /// </summary>
         private void UpdateGameModsListView()
         {
-            ListGameMods.Items.Clear();
-            ListGameMods.Items.AddRange(_modRegistry.Mods.Where(
+            ListDatabaseMods.Items.Clear();
+            ListDatabaseMods.Items.AddRange(_modRegistry.Mods.Where(
                 mod => mod.Installed
                 && GetAllowedModStatuses().Contains(mod.Installation.Status)
                 && mod.Type == ModType.DATABASE).Select(mod => mod.Name).ToArray());
@@ -375,7 +375,7 @@ namespace AuroraLoader
             ButtonUpdateAurora.Enabled = false;
 
             var mods = _modRegistry.Mods.Where(mod =>
-            (ListGameMods.CheckedItems != null && ListGameMods.CheckedItems.Contains(mod.Name))
+            (ListDatabaseMods.CheckedItems != null && ListDatabaseMods.CheckedItems.Contains(mod.Name))
             || (ListUtilities.CheckedItems != null && ListUtilities.CheckedItems.Contains(mod.Name))).ToList();
 
             Mod executableMod;

--- a/AuroraLoader/FormMain.cs
+++ b/AuroraLoader/FormMain.cs
@@ -10,6 +10,7 @@ using System.Drawing;
 using System.IO;
 using System.Linq;
 using System.Runtime.CompilerServices;
+using System.Text.RegularExpressions;
 using System.Threading;
 using System.Transactions;
 using System.Windows.Forms;
@@ -43,7 +44,7 @@ namespace AuroraLoader
             {
                 InstallAurora(executablePath);
             }
-            CheckEnableGameMods.Checked = false;
+
             RefreshAuroraInstallData();
             UpdateUtilitiesListView();
             UpdateLaunchExeCombo();
@@ -51,7 +52,13 @@ namespace AuroraLoader
             UpdateManageModsListView();
 
             Cursor = Cursors.Default;
-            TabMods.SelectedTab = TabUtilities;
+            CheckEnableGameMods.Enabled = true;
+            ComboSelectLaunchExe.Enabled = false;
+            ListGameMods.Enabled = false;
+            CheckApproved.Enabled = false;
+            CheckPower.Enabled = false;
+            CheckPublic.Enabled = false;
+            TabMods.SelectedTab = TabGameMods;
         }
 
         private void InstallAurora(string executablePath)
@@ -129,8 +136,8 @@ namespace AuroraLoader
         /// </summary>
         private void UpdateUtilitiesListView()
         {
-            ListUtilityMods.Items.Clear();
-            ListUtilityMods.Items.AddRange(_modRegistry.Mods.Where(
+            ListUtilities.Items.Clear();
+            ListUtilities.Items.AddRange(_modRegistry.Mods.Where(
                 m => m.Installed
                 && (m.Type == ModType.UTILITY || m.Type == ModType.ROOTUTILITY))
                 .Select(mod => mod.Name).ToArray());
@@ -145,7 +152,6 @@ namespace AuroraLoader
                 var result = MessageBox.Show("By using game mods you agree to not post bug reports to the official Aurora bug report channels.", "Warning!", MessageBoxButtons.OKCancel);
                 if (result == DialogResult.OK)
                 {
-                    GroupMods.Enabled = true;
                     ButtonAuroraBugs.Enabled = false;
                     ButtonAuroraBugs.ForeColor = Color.Black;
                     ButtonModBugs.Enabled = true;
@@ -153,7 +159,9 @@ namespace AuroraLoader
 
                     ComboSelectLaunchExe.Enabled = true;
                     ListGameMods.Enabled = true;
-                    ButtonInstallOrUpdate.Enabled = true;
+                    CheckApproved.Enabled = true;
+                    CheckPower.Enabled = true;
+                    CheckPublic.Enabled = true;
                 }
                 else
                 {
@@ -162,15 +170,19 @@ namespace AuroraLoader
             }
             if (!CheckEnableGameMods.Checked)
             {
-                GroupMods.Enabled = false;
                 ButtonAuroraBugs.Enabled = true;
                 ButtonAuroraBugs.ForeColor = Color.OrangeRed;
                 ButtonModBugs.Enabled = false;
                 ButtonModBugs.ForeColor = Color.Black;
 
+                ComboSelectLaunchExe.SelectedItem = ComboSelectLaunchExe.Items[0];
+
+                CheckEnableGameMods.Enabled = true;
                 ComboSelectLaunchExe.Enabled = false;
                 ListGameMods.Enabled = false;
-                ButtonInstallOrUpdate.Enabled = false;
+                CheckApproved.Enabled = false;
+                CheckPower.Enabled = false;
+                CheckPublic.Enabled = false;
             }
         }
 
@@ -361,14 +373,10 @@ namespace AuroraLoader
             ButtonMultiPlayer.Enabled = false;
             ButtonInstallAurora.Enabled = false;
             ButtonUpdateAurora.Enabled = false;
-            ButtonInstallOrUpdate.Enabled = false;
-
-            TabUtilities.Enabled = false;
-            TabGameMods.Enabled = false;
 
             var mods = _modRegistry.Mods.Where(mod =>
             (ListGameMods.CheckedItems != null && ListGameMods.CheckedItems.Contains(mod.Name))
-            || (ListUtilityMods.CheckedItems != null && ListUtilityMods.CheckedItems.Contains(mod.Name))).ToList();
+            || (ListUtilities.CheckedItems != null && ListUtilities.CheckedItems.Contains(mod.Name))).ToList();
 
             Mod executableMod;
             if (ComboSelectLaunchExe.SelectedItem != null && (string)ComboSelectLaunchExe.SelectedItem != "Base game")
@@ -456,9 +464,6 @@ namespace AuroraLoader
             ButtonSinglePlayer.Enabled = true;
             RefreshAuroraInstallData();
             ButtonInstallOrUpdate.Enabled = true;
-
-            TabUtilities.Enabled = true;
-            TabGameMods.Enabled = true;
         }
 
         private void ButtonSinglePlayer_Click(object sender, EventArgs e)
@@ -518,6 +523,11 @@ namespace AuroraLoader
         }
 
         private void TabMods_SelectedIndexChanged(object sender, EventArgs e)
+        {
+
+        }
+
+        private void ListUtilities_SelectedIndexChanged(object sender, EventArgs e)
         {
 
         }

--- a/AuroraLoader/FormMain.cs
+++ b/AuroraLoader/FormMain.cs
@@ -300,27 +300,28 @@ namespace AuroraLoader
 
         private void ListManageMods_SelectedIndexChanged(object sender, EventArgs e)
         {
+            ButtonInstallOrUpdate.Enabled = false;
+            ButtonConfigureMod.Enabled = false;
+
             if (ListManageMods.SelectedItems.Count > 0)
             {
                 var selected = _modRegistry.Mods.Single(mod => mod.Name == ListManageMods.SelectedItems[0].Text);
-                if (selected.Installed && selected.CanBeUpdated)
+                if (selected.Installed)
                 {
                     ButtonInstallOrUpdate.Text = "Update";
-                    ButtonInstallOrUpdate.Enabled = true;
-                }
-                else if (!selected.Installed)
-                {
-                    ButtonInstallOrUpdate.Text = "Install";
-                    ButtonInstallOrUpdate.Enabled = true;
-                }
-
-                if (selected.Installed && selected.Installation.ModInternalConfigFile != null)
-                {
-                    ButtonConfigureMod.Enabled = true;
+                    if (selected.CanBeUpdated)
+                    {
+                        ButtonInstallOrUpdate.Enabled = true;
+                    }
+                    if (selected.Installation.ModInternalConfigFile != null)
+                    {
+                        ButtonConfigureMod.Enabled = true;
+                    }
                 }
                 else
                 {
-                    ButtonConfigureMod.Enabled = false;
+                    ButtonInstallOrUpdate.Text = "Install";
+                    ButtonInstallOrUpdate.Enabled = true;
                 }
             }
             else

--- a/AuroraLoader/FormMain.cs
+++ b/AuroraLoader/FormMain.cs
@@ -354,6 +354,7 @@ namespace AuroraLoader
             UpdateManageModsListView();
             UpdateGameModsListView();
             UpdateUtilitiesListView();
+            UpdateLaunchExeCombo();
             Cursor = Cursors.Default;
         }
 


### PR DESCRIPTION
Features:
- Combined utility and game mod tabs into one
- Centralized mod configuration on the Manage tab

Bugfixes:
- Fixed the EXE mod launch dropdown not being updated after downloading new mods
- Any EXE mod is now de-selected when mods are disabled
- Some UI tweaks and additional labels
- ButtonInstallOrUpdate's text now updates properly when changing selections

![image](https://user-images.githubusercontent.com/711467/80307920-25f8d800-879a-11ea-9857-9936c12f273e.png)