### PR TITLE
Bugfixes

### DIFF
--- a/AuroraLoader/FormMain.cs
+++ b/AuroraLoader/FormMain.cs
@@ -294,7 +294,7 @@ namespace AuroraLoader
                     var li = new ListViewItem(new string[] {
                         mod.Name,
                         mod.Type.ToString(),
-                        mod.Installation?.TargetAuroraVersion.ToString(),
+                        mod.Installation?.TargetAuroraVersion.ToString() == "1" ? "Any" : mod.Installation?.TargetAuroraVersion.ToString(),
                         mod.Installation?.Version.ToString(),
                         mod.Listing?.LatestVersion.ToString() ?? "Not found"
                     });

--- a/AuroraLoader/Registry/LocalModRegistry.cs
+++ b/AuroraLoader/Registry/LocalModRegistry.cs
@@ -41,7 +41,7 @@ namespace AuroraLoader.Registry
         {
             var mods = new List<ModConfiguration>();
             // Load the mod configuration for AuroraLoader itself
-            if (File.Exists(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "mod.ini")))
+            if (File.Exists(Path.Combine(Program.AuroraLoaderExecutableDirectory, "mod.ini")))
             {
                 var auroraLoader = ModConfigurationReader.ModConfigurationFromIni(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "mod.ini"));
                 var auroraLoaderModDirectory = Path.Combine(ModDirectory, auroraLoader.Name, auroraLoader.Version.ToString());
@@ -49,7 +49,7 @@ namespace AuroraLoader.Registry
                 {
                     Directory.CreateDirectory(auroraLoaderModDirectory);
                 }
-                File.Move(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "mod.ini"), Path.Combine(auroraLoaderModDirectory, "mod.ini"), true);
+                File.Move(Path.Combine(Program.AuroraLoaderExecutableDirectory, "mod.ini"), Path.Combine(auroraLoaderModDirectory, "mod.ini"), true);
                 File.Copy(Path.Combine(Program.AuroraLoaderExecutableDirectory, "AuroraLoader.exe"), Path.Combine(auroraLoaderModDirectory, "AuroraLoader.Exe"), true);
             }
 

--- a/AuroraLoader/Registry/ModRegistry.cs
+++ b/AuroraLoader/Registry/ModRegistry.cs
@@ -55,11 +55,19 @@ namespace AuroraLoader.Registry
                 }
             }
 
-            // Specially load in AuroraLoader itself
-            var auroraLoaderModInstallation = _localRegistry.ModInstallations.Single(i => i.Name == "AuroraLoader");
-            var auroraLoaderModListing = new ModListing(auroraLoaderModInstallation.Name, auroraLoaderModInstallation.Updates);
-            mods.Add(new Mod(auroraLoaderModInstallation, auroraLoaderModListing));
-            installedMods.Remove(auroraLoaderModInstallation);
+            try
+            {
+                // Specially load in AuroraLoader itself
+                var auroraLoaderModInstallation = _localRegistry.ModInstallations.Single(i => i.Name == "AuroraLoader");
+                var auroraLoaderModListing = new ModListing(auroraLoaderModInstallation.Name, auroraLoaderModInstallation.Updates);
+                mods.Add(new Mod(auroraLoaderModInstallation, auroraLoaderModListing));
+                installedMods.Remove(auroraLoaderModInstallation);
+            }
+            catch (Exception exc)
+            {
+                Log.Error($"Failed while loading AuroraLoader installation", exc);
+            }
+
 
             // Handle mods we couldn't find a listing for in the registry
             foreach (var installedMod in installedMods)

--- a/AuroraLoader/mod.ini
+++ b/AuroraLoader/mod.ini
@@ -1,6 +1,6 @@
 ﻿Name=AuroraLoader
 Type=Exe
-Version=0.21.2
+Version=0.21.3
 AuroraVersion=1
 Status=Approved
 Exe=AuroraLoader.exe

--- a/updates.txt
+++ b/updates.txt
@@ -1,5 +1,3 @@
 ﻿0.20.0=https://github.com/Aurora-Modders/AuroraLoader/releases/download/0.20.0/AuroraLoader.0.20.0.zip
 0.20.2=https://github.com/Aurora-Modders/AuroraLoader/releases/download/0.20.0/AuroraLoader.0.20.2.zip
-0.21.0-rc=https://github.com/Aurora-Modders/AuroraLoader/releases/download/0.21.0-rc/AuroraLoader.0.21.0.zip
-0.21.1-rc=https://github.com/Aurora-Modders/AuroraLoader/releases/download/0.21.1-rc/AuroraLoader.0.21.1.zip
-0.21.2=https://github.com/Aurora-Modders/AuroraLoader/releases/download/0.21.2/AuroraLoader.0.21.2.zip
+0.21.3=https://github.com/Aurora-Modders/AuroraLoader/releases/download/0.21.3/AuroraLoader.0.21.3.zip


### PR DESCRIPTION
Features:

- Print 'Any' instead of '1' when a mod can work with any Aurora version starting with 1

Bugs
- Fix a breaking path handling regression I just introduced
- Guard against failures when loading current AuroraLoader version for the first time