### PR TITLE
Harden config file loading

### DIFF
--- a/AuroraLoader/FormMain.cs
+++ b/AuroraLoader/FormMain.cs
@@ -382,32 +382,49 @@ namespace AuroraLoader
         /// </summary>
         private void ButtonConfigureMod_Click(object sender, EventArgs e)
         {
-            var mod = _modRegistry.Mods.Single(mod => mod.Name == ListManageMods.SelectedItems[0].Text);
-
-            var pieces = mod.Installation.ModInternalConfigFile.Split(' ');
-            var exe = pieces[0];
-            var args = "";
-            if (pieces.Length > 1)
+            try
             {
-                for (int i = 1; i < pieces.Length; i++)
+                var mod = _modRegistry.Mods.Single(mod => mod.Name == ListManageMods.SelectedItems[0].Text);
+                if (mod.Installation == null || mod.Installation.ModFolder == null || mod.Installation.ModInternalConfigFile == null)
                 {
-                    args += " " + pieces[i];
+                    throw new Exception("Invalid mod selected for configuration");
                 }
 
-                args = args.Substring(1);
+                var pieces = mod.Installation.ModInternalConfigFile.Split(' ');
+                var exe = pieces[0];
+                var args = "";
+                if (pieces.Length > 1)
+                {
+                    for (int i = 1; i < pieces.Length; i++)
+                    {
+                        args += " " + pieces[i];
+                    }
+
+                    args = args.Substring(1);
+                }
+
+                Log.Debug($"{mod.Name} config file: run {exe} in {mod.Installation.ModFolder} with args {args}");
+                if (!File.Exists(Path.Combine(mod.Installation.ModFolder, exe)))
+                {
+                    MessageBox.Show($"Couldn't launch {Path.Combine(mod.Installation.ModFolder, exe)} - make sure {Path.Combine(mod.Installation.ModFolder, "mod.ini")} is correctly configured.");
+                    return;
+                }
+                var info = new ProcessStartInfo()
+                {
+                    WorkingDirectory = mod.Installation.ModFolder,
+                    FileName = exe,
+                    Arguments = args,
+                    UseShellExecute = true,
+                    CreateNoWindow = true
+                };
+
+                Process.Start(info);
+            }
+            catch (Exception exc)
+            {
+                Log.Error($"Failed while trying to open {ListManageMods.SelectedItems[0]} config file", exc);
             }
 
-            Log.Debug("Running: " + mod.Installation.ModInternalConfigFile);
-            var info = new ProcessStartInfo()
-            {
-                WorkingDirectory = mod.Installation.ModFolder,
-                FileName = exe,
-                Arguments = args,
-                UseShellExecute = true,
-                CreateNoWindow = true
-            };
-
-            Process.Start(info);
         }
 
         private void StartGame()

--- a/AuroraLoader/Registry/Mirror.cs
+++ b/AuroraLoader/Registry/Mirror.cs
@@ -48,6 +48,7 @@ namespace AuroraLoader.Registry
                 catch (Exception e)
                 {
                     Log.Error($"Failed to download Aurora version listing from {VersionsUrl}", e);
+                    throw;
                 }
 
             }
@@ -80,7 +81,7 @@ namespace AuroraLoader.Registry
                 catch (Exception e)
                 {
                     Log.Error($"Failed to download mod listing from {ModsUrl}", e);
-
+                    throw;
                 }
             }
 

--- a/AuroraLoader/Registry/MirrorRegistry.cs
+++ b/AuroraLoader/Registry/MirrorRegistry.cs
@@ -29,7 +29,14 @@ namespace AuroraLoader.Registry
             {
                 foreach (var rootUrl in File.ReadAllLines(Path.Combine(Program.AuroraLoaderExecutableDirectory, "mirrors.ini")))
                 {
-                    mirrors.Add(new Mirror(_configuration, rootUrl));
+                    try
+                    {
+                        mirrors.Add(new Mirror(_configuration, rootUrl));
+                    }
+                    catch (Exception exc)
+                    {
+                        Log.Error($"Failed to add {rootUrl} as a mirror", exc);
+                    }
                 }
             }
             catch (Exception e)
@@ -38,11 +45,6 @@ namespace AuroraLoader.Registry
             }
 
             Mirrors = mirrors;
-        }
-
-        public void AddMirror(Mirror mirror)
-        {
-            Mirrors.Add(mirror);
         }
     }
 }

--- a/AuroraLoader/Registry/ModRegistry.cs
+++ b/AuroraLoader/Registry/ModRegistry.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.IO.Compression;
 using System.Linq;
 using System.Net;
+using System.Windows.Forms;
 using AuroraLoader.Mods;
 using Microsoft.Extensions.Configuration;
 
@@ -134,7 +135,8 @@ namespace AuroraLoader.Registry
             }
             catch (Exception e)
             {
-                Log.Error($"Failed while installing or updating {mod.Name}", e);
+                Log.Error($"Failed while installing or updating {mod.Name} from {mod.Listing.LatestVersionUrl}", e);
+                MessageBox.Show($"Failed to download {mod.Name} from {mod.Listing.LatestVersionUrl}!");
             }
             finally
             {


### PR DESCRIPTION
Hardening this area a bit since I managed to crash the loader while testing AuroraDashboard with a copy/pasted mod.ini.

Bugs:
- Loader no longer crashes when a `mod.ini` points to a bad or nonexistent config file
- Loader no longer crashes if a mirror doesn't work / you're not connected to the internet
- Modals for both of the above with actionable information
- A 'mod download failed' modal to give the user some feedback when that happens (previously, it looked like something was happening)

Not pictured: AuroraLoader hard crashing
Pictured: new helpful error message
![image](https://user-images.githubusercontent.com/711467/80443001-2bf6d200-88dc-11ea-8c5b-05f0a2ad65f0.png)
