### PR TITLE
0.23.4

### DIFF
--- a/AuroraLoader/AuroraLoader.csproj
+++ b/AuroraLoader/AuroraLoader.csproj
@@ -19,6 +19,16 @@
   </ItemGroup>
 
   <ItemGroup>
+    <None Remove="Aurora.ico" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Content Include="Aurora.ico">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="3.1.3" />
     <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="3.1.3" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.3" />

--- a/AuroraLoader/FormMain.Designer.cs
+++ b/AuroraLoader/FormMain.Designer.cs
@@ -158,7 +158,7 @@ namespace AuroraLoader
             this.CheckEnableMods.TabIndex = 21;
             this.CheckEnableMods.Text = "Enable Mods";
             this.CheckEnableMods.UseVisualStyleBackColor = true;
-            this.CheckEnableMods.CheckedChanged += new System.EventHandler(this.CheckEnableGameMod_CheckChanged);
+            this.CheckEnableMods.CheckedChanged += new System.EventHandler(this.CheckEnableMods_CheckChanged);
             // 
             // CheckEnablePoweruserMods
             // 

--- a/AuroraLoader/FormMain.Designer.cs
+++ b/AuroraLoader/FormMain.Designer.cs
@@ -72,21 +72,21 @@ namespace AuroraLoader
             // LabelAuroraVersion
             // 
             this.LabelAuroraVersion.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.LabelAuroraVersion.Location = new System.Drawing.Point(664, 934);
+            this.LabelAuroraVersion.Location = new System.Drawing.Point(674, 934);
             this.LabelAuroraVersion.Margin = new System.Windows.Forms.Padding(6, 0, 6, 0);
             this.LabelAuroraVersion.Name = "LabelAuroraVersion";
-            this.LabelAuroraVersion.Size = new System.Drawing.Size(210, 25);
+            this.LabelAuroraVersion.Size = new System.Drawing.Size(200, 25);
             this.LabelAuroraVersion.TabIndex = 7;
-            this.LabelAuroraVersion.Text = "Aurora v#.##.# (789ABC)";
+            this.LabelAuroraVersion.Text = "Aurora v#.##.#";
             this.LabelAuroraVersion.TextAlign = System.Drawing.ContentAlignment.TopRight;
             // 
             // ButtonUpdateAurora
             // 
             this.ButtonUpdateAurora.Enabled = false;
-            this.ButtonUpdateAurora.Location = new System.Drawing.Point(490, 895);
+            this.ButtonUpdateAurora.Location = new System.Drawing.Point(505, 895);
             this.ButtonUpdateAurora.Margin = new System.Windows.Forms.Padding(6, 7, 6, 7);
             this.ButtonUpdateAurora.Name = "ButtonUpdateAurora";
-            this.ButtonUpdateAurora.Size = new System.Drawing.Size(150, 45);
+            this.ButtonUpdateAurora.Size = new System.Drawing.Size(165, 45);
             this.ButtonUpdateAurora.TabIndex = 12;
             this.ButtonUpdateAurora.Text = "Update Aurora";
             this.ButtonUpdateAurora.UseVisualStyleBackColor = true;
@@ -120,7 +120,7 @@ namespace AuroraLoader
             this.ButtonUpdateAuroraLoader.Location = new System.Drawing.Point(328, 895);
             this.ButtonUpdateAuroraLoader.Margin = new System.Windows.Forms.Padding(6, 7, 6, 7);
             this.ButtonUpdateAuroraLoader.Name = "ButtonUpdateAuroraLoader";
-            this.ButtonUpdateAuroraLoader.Size = new System.Drawing.Size(150, 45);
+            this.ButtonUpdateAuroraLoader.Size = new System.Drawing.Size(165, 45);
             this.ButtonUpdateAuroraLoader.TabIndex = 12;
             this.ButtonUpdateAuroraLoader.Text = "Update Loader";
             this.ButtonUpdateAuroraLoader.UseVisualStyleBackColor = true;
@@ -128,10 +128,10 @@ namespace AuroraLoader
             // 
             // ButtonReadme
             // 
-            this.ButtonReadme.Location = new System.Drawing.Point(720, 43);
+            this.ButtonReadme.Location = new System.Drawing.Point(720, 45);
             this.ButtonReadme.Margin = new System.Windows.Forms.Padding(6, 7, 6, 7);
             this.ButtonReadme.Name = "ButtonReadme";
-            this.ButtonReadme.Size = new System.Drawing.Size(120, 35);
+            this.ButtonReadme.Size = new System.Drawing.Size(120, 40);
             this.ButtonReadme.TabIndex = 13;
             this.ButtonReadme.Text = "Readme";
             this.ButtonReadme.UseVisualStyleBackColor = true;
@@ -140,10 +140,10 @@ namespace AuroraLoader
             // LabelAuroraLoaderVersion
             // 
             this.LabelAuroraLoaderVersion.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.LabelAuroraLoaderVersion.Location = new System.Drawing.Point(664, 909);
+            this.LabelAuroraLoaderVersion.Location = new System.Drawing.Point(674, 909);
             this.LabelAuroraLoaderVersion.Margin = new System.Windows.Forms.Padding(6, 0, 6, 0);
             this.LabelAuroraLoaderVersion.Name = "LabelAuroraLoaderVersion";
-            this.LabelAuroraLoaderVersion.Size = new System.Drawing.Size(210, 25);
+            this.LabelAuroraLoaderVersion.Size = new System.Drawing.Size(200, 25);
             this.LabelAuroraLoaderVersion.TabIndex = 7;
             this.LabelAuroraLoaderVersion.Text = "Loader v#.##.#";
             this.LabelAuroraLoaderVersion.TextAlign = System.Drawing.ContentAlignment.TopRight;

--- a/AuroraLoader/FormMain.Designer.cs
+++ b/AuroraLoader/FormMain.Designer.cs
@@ -170,7 +170,7 @@ namespace AuroraLoader
             this.CheckEnablePoweruserMods.TabIndex = 23;
             this.CheckEnablePoweruserMods.Text = "Enable Poweruser Mods";
             this.CheckEnablePoweruserMods.UseVisualStyleBackColor = true;
-            this.CheckEnablePoweruserMods.CheckedChanged += new System.EventHandler(this.CheckModStatus_CheckChanged);
+            this.CheckEnablePoweruserMods.CheckedChanged += new System.EventHandler(this.CheckEnablePoweruserMod_CheckChanged);
             // 
             // ComboSelectExecutableMod
             // 
@@ -181,7 +181,6 @@ namespace AuroraLoader
             this.ComboSelectExecutableMod.Name = "ComboSelectExecutableMod";
             this.ComboSelectExecutableMod.Size = new System.Drawing.Size(343, 33);
             this.ComboSelectExecutableMod.TabIndex = 25;
-            this.ComboSelectExecutableMod.SelectedIndexChanged += new System.EventHandler(this.ComboSelectLaunchExe_SelectedIndexChanged);
             // 
             // ListDatabaseMods
             // 
@@ -281,7 +280,7 @@ namespace AuroraLoader
             this.LinkDiscord.TabIndex = 36;
             this.LinkDiscord.TabStop = true;
             this.LinkDiscord.Text = "Discord";
-            this.LinkDiscord.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.LinkModBug_LinkClicked);
+            this.LinkDiscord.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.LinkDiscord_LinkClicked);
             // 
             // LabelUtilities
             // 

--- a/AuroraLoader/FormMain.Designer.cs
+++ b/AuroraLoader/FormMain.Designer.cs
@@ -91,7 +91,7 @@ namespace AuroraLoader
             this.LabelChecksum.Name = "LabelChecksum";
             this.LabelChecksum.Size = new System.Drawing.Size(153, 25);
             this.LabelChecksum.TabIndex = 8;
-            this.LabelChecksum.Text = "Aurora checksum:";
+            this.LabelChecksum.Text = "Aurora checksum: Unknown";
             // 
             // ButtonUpdateAurora
             // 
@@ -315,7 +315,7 @@ namespace AuroraLoader
             this.LinkSubreddit.TabIndex = 35;
             this.LinkSubreddit.TabStop = true;
             this.LinkSubreddit.Text = "Mod Subreddit";
-            this.LinkSubreddit.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.LinkSubreddit_LinkClicked);
+            this.LinkSubreddit.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.LinkVanillaSubreddit_LinkClicked);
             // 
             // LinkModdedBug
             // 
@@ -327,7 +327,7 @@ namespace AuroraLoader
             this.LinkModdedBug.TabIndex = 36;
             this.LinkModdedBug.TabStop = true;
             this.LinkModdedBug.Text = "Report a Bug";
-            this.LinkModdedBug.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.LinkModdedBug_LinkClicked);
+            this.LinkModdedBug.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.LinkModBug_LinkClicked);
             // 
             // LabelExeMod
             // 
@@ -362,12 +362,12 @@ namespace AuroraLoader
             // ManageMods
             // 
             this.ManageMods.AutoSize = true;
-            this.ManageMods.Location = new System.Drawing.Point(56, 518);
+            this.ManageMods.Location = new System.Drawing.Point(40, 518);
             this.ManageMods.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.ManageMods.Name = "ManageMods";
-            this.ManageMods.Size = new System.Drawing.Size(198, 25);
+            this.ManageMods.Size = new System.Drawing.Size(131, 25);
             this.ManageMods.TabIndex = 40;
-            this.ManageMods.Text = "Manage Installed Mods";
+            this.ManageMods.Text = "Manage mods:";
             // 
             // FormMain
             // 

--- a/AuroraLoader/FormMain.Designer.cs
+++ b/AuroraLoader/FormMain.Designer.cs
@@ -31,119 +31,96 @@ namespace AuroraLoader
         private void InitializeComponent()
         {
             this.ButtonSinglePlayer = new System.Windows.Forms.Button();
-            this.LabelVersion = new System.Windows.Forms.Label();
-            this.LabelChecksum = new System.Windows.Forms.Label();
+            this.LabelAuroraVersion = new System.Windows.Forms.Label();
             this.ButtonUpdateAurora = new System.Windows.Forms.Button();
-            this.ButtonMultiPlayer = new System.Windows.Forms.Button();
-            this.TrackVolume = new System.Windows.Forms.TrackBar();
-            this.CheckMusic = new System.Windows.Forms.CheckBox();
+            this.TrackMusicVolume = new System.Windows.Forms.TrackBar();
+            this.CheckEnableMusic = new System.Windows.Forms.CheckBox();
             this.ButtonUpdateAuroraLoader = new System.Windows.Forms.Button();
             this.ButtonReadme = new System.Windows.Forms.Button();
             this.LabelAuroraLoaderVersion = new System.Windows.Forms.Label();
-            this.CheckEnableGameMods = new System.Windows.Forms.CheckBox();
-            this.CheckPublic = new System.Windows.Forms.CheckBox();
-            this.CheckPower = new System.Windows.Forms.CheckBox();
-            this.CheckApproved = new System.Windows.Forms.CheckBox();
-            this.ComboSelectLaunchExe = new System.Windows.Forms.ComboBox();
+            this.CheckEnableMods = new System.Windows.Forms.CheckBox();
+            this.CheckEnablePoweruserMods = new System.Windows.Forms.CheckBox();
+            this.ComboSelectExecutableMod = new System.Windows.Forms.ComboBox();
             this.ListDatabaseMods = new System.Windows.Forms.CheckedListBox();
             this.ListUtilities = new System.Windows.Forms.CheckedListBox();
-            this.ButtonInstallOrUpdate = new System.Windows.Forms.Button();
+            this.ButtonInstallOrUpdateMod = new System.Windows.Forms.Button();
             this.ButtonConfigureMod = new System.Windows.Forms.Button();
             this.ListManageMods = new System.Windows.Forms.ListView();
             this.LinkForums = new System.Windows.Forms.LinkLabel();
-            this.LinkVanillaBug = new System.Windows.Forms.LinkLabel();
+            this.LinkReportBug = new System.Windows.Forms.LinkLabel();
             this.LinkSubreddit = new System.Windows.Forms.LinkLabel();
-            this.LinkModdedBug = new System.Windows.Forms.LinkLabel();
-            this.LabelExeMod = new System.Windows.Forms.Label();
+            this.LinkDiscord = new System.Windows.Forms.LinkLabel();
             this.LabelUtilities = new System.Windows.Forms.Label();
-            this.LabelDBMods = new System.Windows.Forms.Label();
+            this.LabelDatabaseMods = new System.Windows.Forms.Label();
             this.ManageMods = new System.Windows.Forms.Label();
-            ((System.ComponentModel.ISupportInitialize)(this.TrackVolume)).BeginInit();
+            this.LinkModSubreddit = new System.Windows.Forms.LinkLabel();
+            this.ButtonMultiplayer = new System.Windows.Forms.Button();
+            ((System.ComponentModel.ISupportInitialize)(this.TrackMusicVolume)).BeginInit();
             this.SuspendLayout();
             // 
             // ButtonSinglePlayer
             // 
-            this.ButtonSinglePlayer.Location = new System.Drawing.Point(331, 63);
+            this.ButtonSinglePlayer.Location = new System.Drawing.Point(40, 45);
             this.ButtonSinglePlayer.Margin = new System.Windows.Forms.Padding(6, 7, 6, 7);
             this.ButtonSinglePlayer.Name = "ButtonSinglePlayer";
-            this.ButtonSinglePlayer.Size = new System.Drawing.Size(143, 42);
+            this.ButtonSinglePlayer.Size = new System.Drawing.Size(120, 40);
             this.ButtonSinglePlayer.TabIndex = 2;
-            this.ButtonSinglePlayer.Text = "Single Player";
+            this.ButtonSinglePlayer.Text = "Play";
             this.ButtonSinglePlayer.UseVisualStyleBackColor = true;
             this.ButtonSinglePlayer.Click += new System.EventHandler(this.ButtonSinglePlayer_Click);
             // 
-            // LabelVersion
+            // LabelAuroraVersion
             // 
-            this.LabelVersion.AutoSize = true;
-            this.LabelVersion.Location = new System.Drawing.Point(40, 63);
-            this.LabelVersion.Margin = new System.Windows.Forms.Padding(6, 0, 6, 0);
-            this.LabelVersion.Name = "LabelVersion";
-            this.LabelVersion.Size = new System.Drawing.Size(212, 25);
-            this.LabelVersion.TabIndex = 7;
-            this.LabelVersion.Text = "Aurora version: Unknown";
-            this.LabelVersion.Click += new System.EventHandler(this.LabelVersion_Click);
-            // 
-            // LabelChecksum
-            // 
-            this.LabelChecksum.AutoSize = true;
-            this.LabelChecksum.Location = new System.Drawing.Point(40, 105);
-            this.LabelChecksum.Margin = new System.Windows.Forms.Padding(6, 0, 6, 0);
-            this.LabelChecksum.Name = "LabelChecksum";
-            this.LabelChecksum.Size = new System.Drawing.Size(153, 25);
-            this.LabelChecksum.TabIndex = 8;
-            this.LabelChecksum.Text = "Aurora checksum: Unknown";
+            this.LabelAuroraVersion.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.LabelAuroraVersion.Location = new System.Drawing.Point(664, 934);
+            this.LabelAuroraVersion.Margin = new System.Windows.Forms.Padding(6, 0, 6, 0);
+            this.LabelAuroraVersion.Name = "LabelAuroraVersion";
+            this.LabelAuroraVersion.Size = new System.Drawing.Size(210, 25);
+            this.LabelAuroraVersion.TabIndex = 7;
+            this.LabelAuroraVersion.Text = "Aurora v#.##.# (789ABC)";
+            this.LabelAuroraVersion.TextAlign = System.Drawing.ContentAlignment.TopRight;
             // 
             // ButtonUpdateAurora
             // 
             this.ButtonUpdateAurora.Enabled = false;
-            this.ButtonUpdateAurora.Location = new System.Drawing.Point(40, 185);
+            this.ButtonUpdateAurora.Location = new System.Drawing.Point(490, 895);
             this.ButtonUpdateAurora.Margin = new System.Windows.Forms.Padding(6, 7, 6, 7);
             this.ButtonUpdateAurora.Name = "ButtonUpdateAurora";
-            this.ButtonUpdateAurora.Size = new System.Drawing.Size(200, 42);
+            this.ButtonUpdateAurora.Size = new System.Drawing.Size(150, 45);
             this.ButtonUpdateAurora.TabIndex = 12;
             this.ButtonUpdateAurora.Text = "Update Aurora";
             this.ButtonUpdateAurora.UseVisualStyleBackColor = true;
             this.ButtonUpdateAurora.Click += new System.EventHandler(this.ButtonUpdateAurora_Click);
             // 
-            // ButtonMultiPlayer
+            // TrackMusicVolume
             // 
-            this.ButtonMultiPlayer.Enabled = false;
-            this.ButtonMultiPlayer.Location = new System.Drawing.Point(486, 63);
-            this.ButtonMultiPlayer.Margin = new System.Windows.Forms.Padding(6, 7, 6, 7);
-            this.ButtonMultiPlayer.Name = "ButtonMultiPlayer";
-            this.ButtonMultiPlayer.Size = new System.Drawing.Size(143, 42);
-            this.ButtonMultiPlayer.TabIndex = 17;
-            this.ButtonMultiPlayer.Text = "Multi Player";
-            this.ButtonMultiPlayer.UseVisualStyleBackColor = true;
+            this.TrackMusicVolume.Enabled = false;
+            this.TrackMusicVolume.LargeChange = 1;
+            this.TrackMusicVolume.Location = new System.Drawing.Point(378, 99);
+            this.TrackMusicVolume.Margin = new System.Windows.Forms.Padding(6, 7, 6, 7);
+            this.TrackMusicVolume.Name = "TrackMusicVolume";
+            this.TrackMusicVolume.Size = new System.Drawing.Size(231, 69);
+            this.TrackMusicVolume.TabIndex = 20;
+            this.TrackMusicVolume.Value = 4;
             // 
-            // TrackVolume
+            // CheckEnableMusic
             // 
-            this.TrackVolume.Enabled = false;
-            this.TrackVolume.LargeChange = 1;
-            this.TrackVolume.Location = new System.Drawing.Point(426, 228);
-            this.TrackVolume.Margin = new System.Windows.Forms.Padding(6, 7, 6, 7);
-            this.TrackVolume.Name = "TrackVolume";
-            this.TrackVolume.Size = new System.Drawing.Size(231, 69);
-            this.TrackVolume.TabIndex = 20;
-            // 
-            // CheckMusic
-            // 
-            this.CheckMusic.AutoSize = true;
-            this.CheckMusic.Location = new System.Drawing.Point(331, 228);
-            this.CheckMusic.Margin = new System.Windows.Forms.Padding(6, 7, 6, 7);
-            this.CheckMusic.Name = "CheckMusic";
-            this.CheckMusic.Size = new System.Drawing.Size(84, 29);
-            this.CheckMusic.TabIndex = 2;
-            this.CheckMusic.Text = "Music";
-            this.CheckMusic.UseVisualStyleBackColor = true;
-            this.CheckMusic.CheckedChanged += new System.EventHandler(this.CheckMusic_CheckedChanged);
+            this.CheckEnableMusic.AutoSize = true;
+            this.CheckEnableMusic.Location = new System.Drawing.Point(209, 99);
+            this.CheckEnableMusic.Margin = new System.Windows.Forms.Padding(6, 7, 6, 7);
+            this.CheckEnableMusic.Name = "CheckEnableMusic";
+            this.CheckEnableMusic.Size = new System.Drawing.Size(157, 29);
+            this.CheckEnableMusic.TabIndex = 2;
+            this.CheckEnableMusic.Text = "In-Game Music";
+            this.CheckEnableMusic.UseVisualStyleBackColor = true;
+            this.CheckEnableMusic.CheckedChanged += new System.EventHandler(this.CheckMusic_CheckedChanged);
             // 
             // ButtonUpdateAuroraLoader
             // 
-            this.ButtonUpdateAuroraLoader.Location = new System.Drawing.Point(40, 245);
+            this.ButtonUpdateAuroraLoader.Location = new System.Drawing.Point(328, 895);
             this.ButtonUpdateAuroraLoader.Margin = new System.Windows.Forms.Padding(6, 7, 6, 7);
             this.ButtonUpdateAuroraLoader.Name = "ButtonUpdateAuroraLoader";
-            this.ButtonUpdateAuroraLoader.Size = new System.Drawing.Size(200, 42);
+            this.ButtonUpdateAuroraLoader.Size = new System.Drawing.Size(150, 45);
             this.ButtonUpdateAuroraLoader.TabIndex = 12;
             this.ButtonUpdateAuroraLoader.Text = "Update Loader";
             this.ButtonUpdateAuroraLoader.UseVisualStyleBackColor = true;
@@ -151,10 +128,10 @@ namespace AuroraLoader
             // 
             // ButtonReadme
             // 
-            this.ButtonReadme.Location = new System.Drawing.Point(486, 118);
+            this.ButtonReadme.Location = new System.Drawing.Point(720, 43);
             this.ButtonReadme.Margin = new System.Windows.Forms.Padding(6, 7, 6, 7);
             this.ButtonReadme.Name = "ButtonReadme";
-            this.ButtonReadme.Size = new System.Drawing.Size(143, 42);
+            this.ButtonReadme.Size = new System.Drawing.Size(120, 35);
             this.ButtonReadme.TabIndex = 13;
             this.ButtonReadme.Text = "Readme";
             this.ButtonReadme.UseVisualStyleBackColor = true;
@@ -162,109 +139,86 @@ namespace AuroraLoader
             // 
             // LabelAuroraLoaderVersion
             // 
-            this.LabelAuroraLoaderVersion.AutoSize = true;
-            this.LabelAuroraLoaderVersion.Location = new System.Drawing.Point(40, 145);
+            this.LabelAuroraLoaderVersion.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.LabelAuroraLoaderVersion.Location = new System.Drawing.Point(664, 909);
             this.LabelAuroraLoaderVersion.Margin = new System.Windows.Forms.Padding(6, 0, 6, 0);
             this.LabelAuroraLoaderVersion.Name = "LabelAuroraLoaderVersion";
-            this.LabelAuroraLoaderVersion.Size = new System.Drawing.Size(267, 25);
+            this.LabelAuroraLoaderVersion.Size = new System.Drawing.Size(210, 25);
             this.LabelAuroraLoaderVersion.TabIndex = 7;
-            this.LabelAuroraLoaderVersion.Text = "AuroraLoader Version: Unknown";
+            this.LabelAuroraLoaderVersion.Text = "Loader v#.##.#";
+            this.LabelAuroraLoaderVersion.TextAlign = System.Drawing.ContentAlignment.TopRight;
             // 
-            // CheckEnableGameMods
+            // CheckEnableMods
             // 
-            this.CheckEnableGameMods.AutoSize = true;
-            this.CheckEnableGameMods.Location = new System.Drawing.Point(40, 307);
-            this.CheckEnableGameMods.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.CheckEnableGameMods.Name = "CheckEnableGameMods";
-            this.CheckEnableGameMods.Size = new System.Drawing.Size(141, 29);
-            this.CheckEnableGameMods.TabIndex = 21;
-            this.CheckEnableGameMods.Text = "Enable Mods";
-            this.CheckEnableGameMods.UseVisualStyleBackColor = true;
-            this.CheckEnableGameMods.CheckedChanged += new System.EventHandler(this.CheckEnableGameMod_CheckChanged);
+            this.CheckEnableMods.AutoSize = true;
+            this.CheckEnableMods.Location = new System.Drawing.Point(40, 181);
+            this.CheckEnableMods.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.CheckEnableMods.Name = "CheckEnableMods";
+            this.CheckEnableMods.Size = new System.Drawing.Size(141, 29);
+            this.CheckEnableMods.TabIndex = 21;
+            this.CheckEnableMods.Text = "Enable Mods";
+            this.CheckEnableMods.UseVisualStyleBackColor = true;
+            this.CheckEnableMods.CheckedChanged += new System.EventHandler(this.CheckEnableGameMod_CheckChanged);
             // 
-            // CheckPublic
+            // CheckEnablePoweruserMods
             // 
-            this.CheckPublic.AutoSize = true;
-            this.CheckPublic.Location = new System.Drawing.Point(40, 390);
-            this.CheckPublic.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.CheckPublic.Name = "CheckPublic";
-            this.CheckPublic.Size = new System.Drawing.Size(81, 29);
-            this.CheckPublic.TabIndex = 22;
-            this.CheckPublic.Text = "Pubic";
-            this.CheckPublic.UseVisualStyleBackColor = true;
-            this.CheckPublic.CheckedChanged += new System.EventHandler(this.CheckModStatus_CheckChanged);
+            this.CheckEnablePoweruserMods.AutoSize = true;
+            this.CheckEnablePoweruserMods.Location = new System.Drawing.Point(209, 181);
+            this.CheckEnablePoweruserMods.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.CheckEnablePoweruserMods.Name = "CheckEnablePoweruserMods";
+            this.CheckEnablePoweruserMods.Size = new System.Drawing.Size(227, 29);
+            this.CheckEnablePoweruserMods.TabIndex = 23;
+            this.CheckEnablePoweruserMods.Text = "Enable Poweruser Mods";
+            this.CheckEnablePoweruserMods.UseVisualStyleBackColor = true;
+            this.CheckEnablePoweruserMods.CheckedChanged += new System.EventHandler(this.CheckModStatus_CheckChanged);
             // 
-            // CheckPower
+            // ComboSelectExecutableMod
             // 
-            this.CheckPower.AutoSize = true;
-            this.CheckPower.Location = new System.Drawing.Point(40, 432);
-            this.CheckPower.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.CheckPower.Name = "CheckPower";
-            this.CheckPower.Size = new System.Drawing.Size(119, 29);
-            this.CheckPower.TabIndex = 23;
-            this.CheckPower.Text = "Poweruser";
-            this.CheckPower.UseVisualStyleBackColor = true;
-            this.CheckPower.CheckedChanged += new System.EventHandler(this.CheckModStatus_CheckChanged);
-            // 
-            // CheckApproved
-            // 
-            this.CheckApproved.AutoSize = true;
-            this.CheckApproved.Location = new System.Drawing.Point(40, 348);
-            this.CheckApproved.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.CheckApproved.Name = "CheckApproved";
-            this.CheckApproved.Size = new System.Drawing.Size(118, 29);
-            this.CheckApproved.TabIndex = 24;
-            this.CheckApproved.Text = "Approved";
-            this.CheckApproved.UseVisualStyleBackColor = true;
-            this.CheckApproved.CheckedChanged += new System.EventHandler(this.CheckModStatus_CheckChanged);
-            // 
-            // ComboSelectLaunchExe
-            // 
-            this.ComboSelectLaunchExe.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.ComboSelectLaunchExe.FormattingEnabled = true;
-            this.ComboSelectLaunchExe.Location = new System.Drawing.Point(849, 468);
-            this.ComboSelectLaunchExe.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.ComboSelectLaunchExe.Name = "ComboSelectLaunchExe";
-            this.ComboSelectLaunchExe.Size = new System.Drawing.Size(343, 33);
-            this.ComboSelectLaunchExe.TabIndex = 25;
-            this.ComboSelectLaunchExe.SelectedIndexChanged += new System.EventHandler(this.ComboSelectLaunchExe_SelectedIndexChanged);
+            this.ComboSelectExecutableMod.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.ComboSelectExecutableMod.FormattingEnabled = true;
+            this.ComboSelectExecutableMod.Location = new System.Drawing.Point(209, 45);
+            this.ComboSelectExecutableMod.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.ComboSelectExecutableMod.Name = "ComboSelectExecutableMod";
+            this.ComboSelectExecutableMod.Size = new System.Drawing.Size(343, 33);
+            this.ComboSelectExecutableMod.TabIndex = 25;
+            this.ComboSelectExecutableMod.SelectedIndexChanged += new System.EventHandler(this.ComboSelectLaunchExe_SelectedIndexChanged);
             // 
             // ListDatabaseMods
             // 
             this.ListDatabaseMods.FormattingEnabled = true;
-            this.ListDatabaseMods.Location = new System.Drawing.Point(929, 118);
+            this.ListDatabaseMods.Location = new System.Drawing.Point(465, 278);
             this.ListDatabaseMods.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.ListDatabaseMods.Name = "ListDatabaseMods";
-            this.ListDatabaseMods.Size = new System.Drawing.Size(263, 312);
+            this.ListDatabaseMods.Size = new System.Drawing.Size(375, 144);
             this.ListDatabaseMods.TabIndex = 26;
             // 
             // ListUtilities
             // 
             this.ListUtilities.FormattingEnabled = true;
-            this.ListUtilities.Location = new System.Drawing.Point(657, 118);
+            this.ListUtilities.Location = new System.Drawing.Point(40, 278);
             this.ListUtilities.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.ListUtilities.Name = "ListUtilities";
-            this.ListUtilities.Size = new System.Drawing.Size(261, 312);
+            this.ListUtilities.Size = new System.Drawing.Size(375, 144);
             this.ListUtilities.TabIndex = 27;
             this.ListUtilities.SelectedIndexChanged += new System.EventHandler(this.ListUtilityMods_SelectedIndexChanged);
             // 
-            // ButtonInstallOrUpdate
+            // ButtonInstallOrUpdateMod
             // 
-            this.ButtonInstallOrUpdate.Location = new System.Drawing.Point(40, 957);
-            this.ButtonInstallOrUpdate.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.ButtonInstallOrUpdate.Name = "ButtonInstallOrUpdate";
-            this.ButtonInstallOrUpdate.Size = new System.Drawing.Size(143, 42);
-            this.ButtonInstallOrUpdate.TabIndex = 29;
-            this.ButtonInstallOrUpdate.Text = "Install";
-            this.ButtonInstallOrUpdate.UseVisualStyleBackColor = true;
-            this.ButtonInstallOrUpdate.Click += new System.EventHandler(this.ButtonInstallOrUpdateMods_Click);
+            this.ButtonInstallOrUpdateMod.Location = new System.Drawing.Point(40, 895);
+            this.ButtonInstallOrUpdateMod.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.ButtonInstallOrUpdateMod.Name = "ButtonInstallOrUpdateMod";
+            this.ButtonInstallOrUpdateMod.Size = new System.Drawing.Size(135, 45);
+            this.ButtonInstallOrUpdateMod.TabIndex = 29;
+            this.ButtonInstallOrUpdateMod.Text = "Install";
+            this.ButtonInstallOrUpdateMod.UseVisualStyleBackColor = true;
+            this.ButtonInstallOrUpdateMod.Click += new System.EventHandler(this.ButtonInstallOrUpdateMods_Click);
             // 
             // ButtonConfigureMod
             // 
-            this.ButtonConfigureMod.Location = new System.Drawing.Point(191, 957);
+            this.ButtonConfigureMod.Location = new System.Drawing.Point(183, 895);
             this.ButtonConfigureMod.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.ButtonConfigureMod.Name = "ButtonConfigureMod";
-            this.ButtonConfigureMod.Size = new System.Drawing.Size(143, 42);
+            this.ButtonConfigureMod.Size = new System.Drawing.Size(135, 45);
             this.ButtonConfigureMod.TabIndex = 30;
             this.ButtonConfigureMod.Text = "Configure";
             this.ButtonConfigureMod.UseVisualStyleBackColor = true;
@@ -273,10 +227,10 @@ namespace AuroraLoader
             // ListManageMods
             // 
             this.ListManageMods.HideSelection = false;
-            this.ListManageMods.Location = new System.Drawing.Point(40, 548);
+            this.ListManageMods.Location = new System.Drawing.Point(40, 489);
             this.ListManageMods.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.ListManageMods.Name = "ListManageMods";
-            this.ListManageMods.Size = new System.Drawing.Size(1151, 396);
+            this.ListManageMods.Size = new System.Drawing.Size(800, 396);
             this.ListManageMods.TabIndex = 32;
             this.ListManageMods.UseCompatibleStateImageBehavior = false;
             this.ListManageMods.SelectedIndexChanged += new System.EventHandler(this.ListManageMods_SelectedIndexChanged);
@@ -284,130 +238,140 @@ namespace AuroraLoader
             // LinkForums
             // 
             this.LinkForums.AutoSize = true;
-            this.LinkForums.Location = new System.Drawing.Point(331, 313);
+            this.LinkForums.Location = new System.Drawing.Point(708, 85);
             this.LinkForums.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.LinkForums.Name = "LinkForums";
-            this.LinkForums.Size = new System.Drawing.Size(131, 25);
+            this.LinkForums.Size = new System.Drawing.Size(132, 25);
             this.LinkForums.TabIndex = 33;
             this.LinkForums.TabStop = true;
-            this.LinkForums.Text = "Aurora Forums";
+            this.LinkForums.Text = "Official Forums";
             this.LinkForums.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.LinkForums_LinkClicked);
             // 
-            // LinkVanillaBug
+            // LinkReportBug
             // 
-            this.LinkVanillaBug.AutoSize = true;
-            this.LinkVanillaBug.Location = new System.Drawing.Point(463, 313);
-            this.LinkVanillaBug.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.LinkVanillaBug.Name = "LinkVanillaBug";
-            this.LinkVanillaBug.Size = new System.Drawing.Size(115, 25);
-            this.LinkVanillaBug.TabIndex = 34;
-            this.LinkVanillaBug.TabStop = true;
-            this.LinkVanillaBug.Text = "Report a Bug";
-            this.LinkVanillaBug.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.LinkVanillaBug_LinkClicked);
+            this.LinkReportBug.AutoSize = true;
+            this.LinkReportBug.Location = new System.Drawing.Point(725, 185);
+            this.LinkReportBug.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.LinkReportBug.Name = "LinkReportBug";
+            this.LinkReportBug.Size = new System.Drawing.Size(115, 25);
+            this.LinkReportBug.TabIndex = 34;
+            this.LinkReportBug.TabStop = true;
+            this.LinkReportBug.Text = "Report a Bug";
+            this.LinkReportBug.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.LinkVanillaBug_LinkClicked);
             // 
             // LinkSubreddit
             // 
             this.LinkSubreddit.AutoSize = true;
-            this.LinkSubreddit.Location = new System.Drawing.Point(331, 355);
+            this.LinkSubreddit.Location = new System.Drawing.Point(691, 110);
             this.LinkSubreddit.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.LinkSubreddit.Name = "LinkSubreddit";
-            this.LinkSubreddit.Size = new System.Drawing.Size(133, 25);
+            this.LinkSubreddit.Size = new System.Drawing.Size(149, 25);
             this.LinkSubreddit.TabIndex = 35;
             this.LinkSubreddit.TabStop = true;
-            this.LinkSubreddit.Text = "Mod Subreddit";
+            this.LinkSubreddit.Text = "Aurora Subreddit";
             this.LinkSubreddit.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.LinkVanillaSubreddit_LinkClicked);
             // 
-            // LinkModdedBug
+            // LinkDiscord
             // 
-            this.LinkModdedBug.AutoSize = true;
-            this.LinkModdedBug.Location = new System.Drawing.Point(463, 355);
-            this.LinkModdedBug.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.LinkModdedBug.Name = "LinkModdedBug";
-            this.LinkModdedBug.Size = new System.Drawing.Size(115, 25);
-            this.LinkModdedBug.TabIndex = 36;
-            this.LinkModdedBug.TabStop = true;
-            this.LinkModdedBug.Text = "Report a Bug";
-            this.LinkModdedBug.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.LinkModBug_LinkClicked);
-            // 
-            // LabelExeMod
-            // 
-            this.LabelExeMod.AutoSize = true;
-            this.LabelExeMod.Location = new System.Drawing.Point(657, 473);
-            this.LabelExeMod.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.LabelExeMod.Name = "LabelExeMod";
-            this.LabelExeMod.Size = new System.Drawing.Size(142, 25);
-            this.LabelExeMod.TabIndex = 37;
-            this.LabelExeMod.Text = "Executable mod:";
+            this.LinkDiscord.AutoSize = true;
+            this.LinkDiscord.Location = new System.Drawing.Point(767, 160);
+            this.LinkDiscord.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.LinkDiscord.Name = "LinkDiscord";
+            this.LinkDiscord.Size = new System.Drawing.Size(73, 25);
+            this.LinkDiscord.TabIndex = 36;
+            this.LinkDiscord.TabStop = true;
+            this.LinkDiscord.Text = "Discord";
+            this.LinkDiscord.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.LinkModBug_LinkClicked);
             // 
             // LabelUtilities
             // 
             this.LabelUtilities.AutoSize = true;
-            this.LabelUtilities.Location = new System.Drawing.Point(657, 80);
+            this.LabelUtilities.Location = new System.Drawing.Point(40, 248);
             this.LabelUtilities.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.LabelUtilities.Name = "LabelUtilities";
-            this.LabelUtilities.Size = new System.Drawing.Size(69, 25);
+            this.LabelUtilities.Size = new System.Drawing.Size(272, 25);
             this.LabelUtilities.TabIndex = 38;
-            this.LabelUtilities.Text = "Utilities";
+            this.LabelUtilities.Text = "Launch utilities alongside Aurora:";
             // 
-            // LabelDBMods
+            // LabelDatabaseMods
             // 
-            this.LabelDBMods.AutoSize = true;
-            this.LabelDBMods.Location = new System.Drawing.Point(929, 72);
-            this.LabelDBMods.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.LabelDBMods.Name = "LabelDBMods";
-            this.LabelDBMods.Size = new System.Drawing.Size(86, 25);
-            this.LabelDBMods.TabIndex = 39;
-            this.LabelDBMods.Text = "DB Mods";
+            this.LabelDatabaseMods.AutoSize = true;
+            this.LabelDatabaseMods.Location = new System.Drawing.Point(465, 248);
+            this.LabelDatabaseMods.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.LabelDatabaseMods.Name = "LabelDatabaseMods";
+            this.LabelDatabaseMods.Size = new System.Drawing.Size(191, 25);
+            this.LabelDatabaseMods.TabIndex = 39;
+            this.LabelDatabaseMods.Text = "Apply database mods:";
             // 
             // ManageMods
             // 
             this.ManageMods.AutoSize = true;
-            this.ManageMods.Location = new System.Drawing.Point(40, 518);
+            this.ManageMods.Location = new System.Drawing.Point(40, 459);
             this.ManageMods.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.ManageMods.Name = "ManageMods";
             this.ManageMods.Size = new System.Drawing.Size(131, 25);
             this.ManageMods.TabIndex = 40;
             this.ManageMods.Text = "Manage mods:";
             // 
+            // LinkModSubreddit
+            // 
+            this.LinkModSubreddit.AutoSize = true;
+            this.LinkModSubreddit.Location = new System.Drawing.Point(707, 135);
+            this.LinkModSubreddit.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.LinkModSubreddit.Name = "LinkModSubreddit";
+            this.LinkModSubreddit.Size = new System.Drawing.Size(133, 25);
+            this.LinkModSubreddit.TabIndex = 35;
+            this.LinkModSubreddit.TabStop = true;
+            this.LinkModSubreddit.Text = "Mod Subreddit";
+            this.LinkModSubreddit.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.LinkVanillaSubreddit_LinkClicked);
+            // 
+            // ButtonMultiplayer
+            // 
+            this.ButtonMultiplayer.Location = new System.Drawing.Point(40, 99);
+            this.ButtonMultiplayer.Margin = new System.Windows.Forms.Padding(6, 7, 6, 7);
+            this.ButtonMultiplayer.Name = "ButtonMultiplayer";
+            this.ButtonMultiplayer.Size = new System.Drawing.Size(150, 40);
+            this.ButtonMultiplayer.TabIndex = 2;
+            this.ButtonMultiplayer.Text = "Play Multiplayer";
+            this.ButtonMultiplayer.UseVisualStyleBackColor = true;
+            this.ButtonMultiplayer.Click += new System.EventHandler(this.ButtonSinglePlayer_Click);
+            // 
             // FormMain
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(10F, 25F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(1263, 1018);
+            this.ClientSize = new System.Drawing.Size(878, 968);
+            this.Controls.Add(this.ButtonMultiplayer);
+            this.Controls.Add(this.LinkModSubreddit);
             this.Controls.Add(this.ManageMods);
-            this.Controls.Add(this.LabelDBMods);
+            this.Controls.Add(this.LabelDatabaseMods);
             this.Controls.Add(this.LabelUtilities);
-            this.Controls.Add(this.LabelExeMod);
-            this.Controls.Add(this.LinkModdedBug);
+            this.Controls.Add(this.LinkDiscord);
             this.Controls.Add(this.LinkSubreddit);
-            this.Controls.Add(this.LinkVanillaBug);
+            this.Controls.Add(this.LinkReportBug);
             this.Controls.Add(this.LinkForums);
             this.Controls.Add(this.ListManageMods);
             this.Controls.Add(this.ButtonConfigureMod);
-            this.Controls.Add(this.ButtonInstallOrUpdate);
+            this.Controls.Add(this.ButtonInstallOrUpdateMod);
             this.Controls.Add(this.ListUtilities);
             this.Controls.Add(this.ListDatabaseMods);
-            this.Controls.Add(this.ComboSelectLaunchExe);
-            this.Controls.Add(this.CheckApproved);
-            this.Controls.Add(this.CheckPower);
-            this.Controls.Add(this.CheckPublic);
-            this.Controls.Add(this.CheckEnableGameMods);
+            this.Controls.Add(this.ComboSelectExecutableMod);
+            this.Controls.Add(this.CheckEnablePoweruserMods);
+            this.Controls.Add(this.CheckEnableMods);
             this.Controls.Add(this.LabelAuroraLoaderVersion);
             this.Controls.Add(this.ButtonReadme);
             this.Controls.Add(this.ButtonUpdateAuroraLoader);
-            this.Controls.Add(this.CheckMusic);
-            this.Controls.Add(this.TrackVolume);
-            this.Controls.Add(this.ButtonMultiPlayer);
+            this.Controls.Add(this.CheckEnableMusic);
+            this.Controls.Add(this.TrackMusicVolume);
             this.Controls.Add(this.ButtonUpdateAurora);
-            this.Controls.Add(this.LabelChecksum);
-            this.Controls.Add(this.LabelVersion);
+            this.Controls.Add(this.LabelAuroraVersion);
             this.Controls.Add(this.ButtonSinglePlayer);
             this.Margin = new System.Windows.Forms.Padding(6, 7, 6, 7);
             this.Name = "FormMain";
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
             this.Text = "Aurora Loader";
             this.Load += new System.EventHandler(this.FormMain_Load);
-            ((System.ComponentModel.ISupportInitialize)(this.TrackVolume)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.TrackMusicVolume)).EndInit();
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -415,33 +379,30 @@ namespace AuroraLoader
 
         #endregion
         private System.Windows.Forms.Button ButtonSinglePlayer;
-        private System.Windows.Forms.Label LabelVersion;
-        private System.Windows.Forms.Label LabelChecksum;
+        private System.Windows.Forms.Label LabelAuroraVersion;
         private System.Windows.Forms.Button ButtonUpdateAurora;
-        private System.Windows.Forms.Button ButtonMultiPlayer;
-        private System.Windows.Forms.TrackBar TrackVolume;
-        private System.Windows.Forms.CheckBox CheckMusic;
+        private System.Windows.Forms.TrackBar TrackMusicVolume;
+        private System.Windows.Forms.CheckBox CheckEnableMusic;
         private System.Windows.Forms.Button ButtonUpdateAuroraLoader;
         private System.Windows.Forms.Button ButtonReadme;
         private System.Windows.Forms.Label LabelAuroraLoaderVersion;
-        private System.Windows.Forms.CheckBox CheckEnableGameMods;
-        private System.Windows.Forms.CheckBox CheckPublic;
-        private System.Windows.Forms.CheckBox CheckPower;
-        private System.Windows.Forms.CheckBox CheckApproved;
-        private System.Windows.Forms.ComboBox ComboSelectLaunchExe;
+        private System.Windows.Forms.CheckBox CheckEnableMods;
+        private System.Windows.Forms.CheckBox CheckEnablePoweruserMods;
+        private System.Windows.Forms.ComboBox ComboSelectExecutableMod;
         private System.Windows.Forms.CheckedListBox ListDatabaseMods;
         private System.Windows.Forms.CheckedListBox ListUtilities;
-        private System.Windows.Forms.Button ButtonInstallOrUpdate;
+        private System.Windows.Forms.Button ButtonInstallOrUpdateMod;
         private System.Windows.Forms.Button ButtonConfigureMod;
         private System.Windows.Forms.ListView ListManageMods;
         private System.Windows.Forms.LinkLabel LinkForums;
-        private System.Windows.Forms.LinkLabel LinkVanillaBug;
+        private System.Windows.Forms.LinkLabel LinkReportBug;
         private System.Windows.Forms.LinkLabel LinkSubreddit;
-        private System.Windows.Forms.LinkLabel LinkModdedBug;
-        private System.Windows.Forms.Label LabelExeMod;
+        private System.Windows.Forms.LinkLabel LinkDiscord;
         private System.Windows.Forms.Label LabelUtilities;
-        private System.Windows.Forms.Label LabelDBMods;
+        private System.Windows.Forms.Label LabelDatabaseMods;
         private System.Windows.Forms.Label ManageMods;
+        private LinkLabel LinkModSubreddit;
+        private Button ButtonMultiplayer;
     }
 }
 

--- a/AuroraLoader/FormMain.Designer.cs
+++ b/AuroraLoader/FormMain.Designer.cs
@@ -72,10 +72,10 @@ namespace AuroraLoader
             // LabelAuroraVersion
             // 
             this.LabelAuroraVersion.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.LabelAuroraVersion.Location = new System.Drawing.Point(674, 934);
+            this.LabelAuroraVersion.Location = new System.Drawing.Point(684, 934);
             this.LabelAuroraVersion.Margin = new System.Windows.Forms.Padding(6, 0, 6, 0);
             this.LabelAuroraVersion.Name = "LabelAuroraVersion";
-            this.LabelAuroraVersion.Size = new System.Drawing.Size(200, 25);
+            this.LabelAuroraVersion.Size = new System.Drawing.Size(190, 25);
             this.LabelAuroraVersion.TabIndex = 7;
             this.LabelAuroraVersion.Text = "Aurora v#.##.#";
             this.LabelAuroraVersion.TextAlign = System.Drawing.ContentAlignment.TopRight;
@@ -83,10 +83,10 @@ namespace AuroraLoader
             // ButtonUpdateAurora
             // 
             this.ButtonUpdateAurora.Enabled = false;
-            this.ButtonUpdateAurora.Location = new System.Drawing.Point(505, 895);
+            this.ButtonUpdateAurora.Location = new System.Drawing.Point(515, 895);
             this.ButtonUpdateAurora.Margin = new System.Windows.Forms.Padding(6, 7, 6, 7);
             this.ButtonUpdateAurora.Name = "ButtonUpdateAurora";
-            this.ButtonUpdateAurora.Size = new System.Drawing.Size(165, 45);
+            this.ButtonUpdateAurora.Size = new System.Drawing.Size(170, 45);
             this.ButtonUpdateAurora.TabIndex = 12;
             this.ButtonUpdateAurora.Text = "Update Aurora";
             this.ButtonUpdateAurora.UseVisualStyleBackColor = true;
@@ -120,7 +120,7 @@ namespace AuroraLoader
             this.ButtonUpdateAuroraLoader.Location = new System.Drawing.Point(328, 895);
             this.ButtonUpdateAuroraLoader.Margin = new System.Windows.Forms.Padding(6, 7, 6, 7);
             this.ButtonUpdateAuroraLoader.Name = "ButtonUpdateAuroraLoader";
-            this.ButtonUpdateAuroraLoader.Size = new System.Drawing.Size(165, 45);
+            this.ButtonUpdateAuroraLoader.Size = new System.Drawing.Size(170, 45);
             this.ButtonUpdateAuroraLoader.TabIndex = 12;
             this.ButtonUpdateAuroraLoader.Text = "Update Loader";
             this.ButtonUpdateAuroraLoader.UseVisualStyleBackColor = true;
@@ -140,10 +140,10 @@ namespace AuroraLoader
             // LabelAuroraLoaderVersion
             // 
             this.LabelAuroraLoaderVersion.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.LabelAuroraLoaderVersion.Location = new System.Drawing.Point(674, 909);
+            this.LabelAuroraLoaderVersion.Location = new System.Drawing.Point(684, 909);
             this.LabelAuroraLoaderVersion.Margin = new System.Windows.Forms.Padding(6, 0, 6, 0);
             this.LabelAuroraLoaderVersion.Name = "LabelAuroraLoaderVersion";
-            this.LabelAuroraLoaderVersion.Size = new System.Drawing.Size(200, 25);
+            this.LabelAuroraLoaderVersion.Size = new System.Drawing.Size(190, 25);
             this.LabelAuroraLoaderVersion.TabIndex = 7;
             this.LabelAuroraLoaderVersion.Text = "Loader v#.##.#";
             this.LabelAuroraLoaderVersion.TextAlign = System.Drawing.ContentAlignment.TopRight;

--- a/AuroraLoader/FormMain.cs
+++ b/AuroraLoader/FormMain.cs
@@ -185,15 +185,6 @@ namespace AuroraLoader
                 .Select(mod => mod.Name).ToArray());
         }
 
-        /* Game mods tab */
-
-        private void CheckEnableGameMods_CheckChanged(object sender, EventArgs e)
-        {
-            UpdateExecutableModCombo();
-            UpdateDatabaseModListView();
-            UpdateUtilitiesListView();
-        }
-
         private IList<ModStatus> GetAllowedModStatuses()
         {
             var approvedStatuses = new List<ModStatus>();
@@ -561,7 +552,7 @@ namespace AuroraLoader
             Program.OpenBrowser(@"https://discordapp.com/channels/314031775892373504/701885084646506628");
         }
 
-        private void CheckEnableGameMod_CheckChanged(object sender, EventArgs e)
+        private void CheckEnableMods_CheckChanged(object sender, EventArgs e)
         {
             if (CheckEnableMods.Checked)
             {

--- a/AuroraLoader/FormMain.cs
+++ b/AuroraLoader/FormMain.cs
@@ -580,7 +580,12 @@ namespace AuroraLoader
 
         }
 
-        private void LinkSubreddit_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
+        private void LinkModSubreddit_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
+        {
+            Process.Start(@"https://www.reddit.com/r/aurora4x_mods/");
+        }
+
+        private void LinkVanillaSubreddit_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
         {
             Process.Start(@"https://www.reddit.com/r/aurora4x_mods/");
         }
@@ -595,11 +600,15 @@ namespace AuroraLoader
             Program.OpenBrowser(@"http://aurora2.pentarch.org/index.php?board=273.0");
         }
 
-        private void LinkModdedBug_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
+        private void LinkModBug_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
         {
             Program.OpenBrowser(@"https://www.reddit.com/r/aurora4x_mods/");
         }
 
+        private void LinkDiscord_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
+        {
+            Program.OpenBrowser(@"https://www.reddit.com/r/aurora4x_mods/");
+        }
 
         private void CheckEnableGameMod_CheckChanged(object sender, EventArgs e)
         {

--- a/AuroraLoader/FormMain.cs
+++ b/AuroraLoader/FormMain.cs
@@ -36,7 +36,7 @@ namespace AuroraLoader
             {
                 Icon = new Icon(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Aurora.ico"));
             }
-            catch (Exception exc)
+            catch
             {
                 Log.Debug("Failed to load icon");
             }
@@ -45,6 +45,12 @@ namespace AuroraLoader
             _ = MessageBox.Show(new Form { TopMost = true }, "AuroraLoader will check for updates and then launch, this might take a moment.");
             Cursor = Cursors.WaitCursor;
 
+            CheckEnableMods.Enabled = true;
+            ComboSelectExecutableMod.Enabled = false;
+            ListDatabaseMods.Enabled = false;
+            CheckEnablePoweruserMods.Enabled = false;
+            ButtonMultiplayer.Enabled = false;
+
             RefreshAuroraInstallData();
             UpdateUtilitiesListView();
             UpdateExecutableModCombo();
@@ -52,12 +58,6 @@ namespace AuroraLoader
             UpdateManageModsListView();
 
             Cursor = Cursors.Default;
-            CheckEnableMods.Enabled = true;
-            ComboSelectExecutableMod.Enabled = false;
-            ListDatabaseMods.Enabled = false;
-            CheckEnablePoweruserMods.Enabled = false;
-            LinkDiscord.Enabled = false;
-
         }
 
         private void ButtonUpdateAurora_Click(object sender, EventArgs e)
@@ -258,7 +258,6 @@ namespace AuroraLoader
             ListManageMods.Clear();
             ListManageMods.AllowColumnReorder = true;
             ListManageMods.FullRowSelect = true;
-            //ListManageMods.Dock = DockStyle.Top;
             ListManageMods.View = View.Details;
             ListManageMods.Columns.Add("Name");
             ListManageMods.Columns.Add("Type");
@@ -283,17 +282,10 @@ namespace AuroraLoader
             }
             ListManageMods.AutoResizeColumns(ColumnHeaderAutoResizeStyle.ColumnContent);
             ListManageMods.AutoResizeColumns(ColumnHeaderAutoResizeStyle.HeaderSize);
-            ButtonInstallOrUpdateMod.Enabled = false;
             ListManageMods.EndUpdate();
-            ListManageMods.Focus();
-            if (ListManageMods.Items.Count > 0)
-            {
-                ListManageMods.Items[0].Selected = true;
-            }
-            else
-            {
-                ButtonConfigureMod.Enabled = false;
-            }
+
+            ButtonInstallOrUpdateMod.Enabled = false;
+            ButtonConfigureMod.Enabled = false;
         }
 
         private void ListManageMods_SelectedIndexChanged(object sender, EventArgs e)
@@ -331,7 +323,6 @@ namespace AuroraLoader
 
         private void ButtonInstallOrUpdateMods_Click(object sender, EventArgs e)
         {
-
             Cursor = Cursors.WaitCursor;
             var mod = _modRegistry.Mods.Single(mod => mod.Name == ListManageMods.SelectedItems[0].Text);
             _modRegistry.InstallOrUpdate(mod, _auroraVersionRegistry.CurrentAuroraVersion);
@@ -547,12 +538,12 @@ namespace AuroraLoader
 
         private void LinkModSubreddit_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
         {
-            Process.Start(@"https://www.reddit.com/r/aurora4x_mods/");
+            Program.OpenBrowser(@"https://www.reddit.com/r/aurora4x_mods/");
         }
 
         private void LinkVanillaSubreddit_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
         {
-            Process.Start(@"https://www.reddit.com/r/aurora");
+            Program.OpenBrowser(@"https://www.reddit.com/r/aurora/");
         }
 
         private void LinkForums_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)

--- a/AuroraLoader/FormMain.cs
+++ b/AuroraLoader/FormMain.cs
@@ -43,13 +43,11 @@ namespace AuroraLoader
             UpdateManageModsListView();
 
             Cursor = Cursors.Default;
-            CheckEnableGameMods.Enabled = true;
-            ComboSelectLaunchExe.Enabled = false;
+            CheckEnableMods.Enabled = true;
+            ComboSelectExecutableMod.Enabled = false;
             ListDatabaseMods.Enabled = false;
-            CheckApproved.Enabled = false;
-            CheckPower.Enabled = false;
-            CheckPublic.Enabled = false;
-            LinkModdedBug.Enabled = false;
+            CheckEnablePoweruserMods.Enabled = false;
+            LinkDiscord.Enabled = false;
 
         }
 
@@ -111,15 +109,13 @@ namespace AuroraLoader
             _auroraVersionRegistry.Update(_auroraVersionRegistry.CurrentAuroraVersion);
             if (_auroraVersionRegistry.CurrentAuroraVersion == null)
             {
-                LabelVersion.Text = "Aurora version: Unknown";
+                LabelAuroraVersion.Text = "Aurora version: Unknown";
             }
             else
             {
                 _modRegistry.Update(_auroraVersionRegistry.CurrentAuroraVersion);
-
-                LabelChecksum.Text = $"Aurora checksum: {_auroraVersionRegistry.CurrentAuroraVersion.Checksum}";
-                LabelVersion.Text = $"Aurora version: {_auroraVersionRegistry.CurrentAuroraVersion.Version}";
-                LabelAuroraLoaderVersion.Text = $"AuroraLoader Version: {_modRegistry.Mods.Single(m => m.Name == "AuroraLoader").Installation.Version}";
+                LabelAuroraVersion.Text = $"Aurora v{_auroraVersionRegistry.CurrentAuroraVersion.Version} ({_auroraVersionRegistry.CurrentAuroraVersion.Checksum})";
+                LabelAuroraLoaderVersion.Text = $"Loader v{_modRegistry.Mods.Single(m => m.Name == "AuroraLoader").Installation.Version}";
 
                 if (_auroraVersionRegistry.CurrentAuroraVersion.Version.CompareTo(_auroraVersionRegistry.AuroraVersions.Max().Version) < 0)
                 {
@@ -190,15 +186,12 @@ namespace AuroraLoader
         private IList<ModStatus> GetAllowedModStatuses()
         {
             var approvedStatuses = new List<ModStatus>();
-            if (CheckApproved.Checked)
+            if (CheckEnableMods.Checked)
             {
                 approvedStatuses.Add(ModStatus.APPROVED);
-            }
-            if (CheckPublic.Checked)
-            {
                 approvedStatuses.Add(ModStatus.PUBLIC);
             }
-            if (CheckPower.Checked)
+            if (CheckEnablePoweruserMods.Checked)
             {
                 approvedStatuses.Add(ModStatus.POWERUSER);
             }
@@ -210,8 +203,8 @@ namespace AuroraLoader
         /// </summary>
         private void UpdateLaunchExeCombo()
         {
-            ComboSelectLaunchExe.Items.Clear();
-            ComboSelectLaunchExe.Items.Add("Base game");
+            ComboSelectExecutableMod.Items.Clear();
+            ComboSelectExecutableMod.Items.Add("Base game");
 
             foreach (var mod in _modRegistry.Mods.Where(
                 mod => mod.Installed
@@ -220,11 +213,11 @@ namespace AuroraLoader
                 && mod.Name != "AuroraLoader"
                 && mod.Installation.WorksForVersion(_auroraVersionRegistry.CurrentAuroraVersion)))
             {
-                ComboSelectLaunchExe.Items.Add(mod.Name);
+                ComboSelectExecutableMod.Items.Add(mod.Name);
             }
-            if (ComboSelectLaunchExe.Items.Count > 0)
+            if (ComboSelectExecutableMod.Items.Count > 0)
             {
-                ComboSelectLaunchExe.SelectedIndex = 0;
+                ComboSelectExecutableMod.SelectedIndex = 0;
             }
         }
 
@@ -233,9 +226,9 @@ namespace AuroraLoader
         /// </summary>
         private void ComboSelectLaunchExe_SelectedIndexChanged(object sender, EventArgs e)
         {
-            if ((string)ComboSelectLaunchExe.SelectedItem != "Base game")
+            if ((string)ComboSelectExecutableMod.SelectedItem != "Base game")
             {
-                var selectedMod = _modRegistry.Mods.Single(mod => mod.Name == (string)ComboSelectLaunchExe.SelectedItem);
+                var selectedMod = _modRegistry.Mods.Single(mod => mod.Name == (string)ComboSelectExecutableMod.SelectedItem);
             }
             else
             {
@@ -293,7 +286,7 @@ namespace AuroraLoader
             }
             ListManageMods.AutoResizeColumns(ColumnHeaderAutoResizeStyle.ColumnContent);
             ListManageMods.AutoResizeColumns(ColumnHeaderAutoResizeStyle.HeaderSize);
-            ButtonInstallOrUpdate.Enabled = false;
+            ButtonInstallOrUpdateMod.Enabled = false;
             ListManageMods.EndUpdate();
             ListManageMods.Focus();
             if (ListManageMods.Items.Count > 0)
@@ -308,7 +301,7 @@ namespace AuroraLoader
 
         private void ListManageMods_SelectedIndexChanged(object sender, EventArgs e)
         {
-            ButtonInstallOrUpdate.Enabled = false;
+            ButtonInstallOrUpdateMod.Enabled = false;
             ButtonConfigureMod.Enabled = false;
 
             if (ListManageMods.SelectedItems.Count > 0)
@@ -316,10 +309,10 @@ namespace AuroraLoader
                 var selected = _modRegistry.Mods.Single(mod => mod.Name == ListManageMods.SelectedItems[0].Text);
                 if (selected.Installed)
                 {
-                    ButtonInstallOrUpdate.Text = "Update";
+                    ButtonInstallOrUpdateMod.Text = "Update";
                     if (selected.CanBeUpdated)
                     {
-                        ButtonInstallOrUpdate.Enabled = true;
+                        ButtonInstallOrUpdateMod.Enabled = true;
                     }
                     if (selected.Installation.ModInternalConfigFile != null)
                     {
@@ -328,14 +321,14 @@ namespace AuroraLoader
                 }
                 else
                 {
-                    ButtonInstallOrUpdate.Text = "Install";
-                    ButtonInstallOrUpdate.Enabled = true;
+                    ButtonInstallOrUpdateMod.Text = "Install";
+                    ButtonInstallOrUpdateMod.Enabled = true;
                 }
             }
             else
             {
-                ButtonInstallOrUpdate.Text = "Update";
-                ButtonInstallOrUpdate.Enabled = false;
+                ButtonInstallOrUpdateMod.Text = "Update";
+                ButtonInstallOrUpdateMod.Enabled = false;
             }
         }
 
@@ -414,7 +407,6 @@ namespace AuroraLoader
             }
 
             ButtonSinglePlayer.Enabled = false;
-            ButtonMultiPlayer.Enabled = false;
             ButtonUpdateAurora.Enabled = false;
 
             var mods = _modRegistry.Mods.Where(mod =>
@@ -422,9 +414,9 @@ namespace AuroraLoader
             || (ListUtilities.CheckedItems != null && ListUtilities.CheckedItems.Contains(mod.Name))).ToList();
 
             Mod executableMod;
-            if (ComboSelectLaunchExe.SelectedItem != null && (string)ComboSelectLaunchExe.SelectedItem != "Base game")
+            if (ComboSelectExecutableMod.SelectedItem != null && (string)ComboSelectExecutableMod.SelectedItem != "Base game")
             {
-                executableMod = _modRegistry.Mods.Single(mod => mod.Name == (string)ComboSelectLaunchExe.SelectedItem);
+                executableMod = _modRegistry.Mods.Single(mod => mod.Name == (string)ComboSelectExecutableMod.SelectedItem);
             }
             else
             {
@@ -457,7 +449,7 @@ namespace AuroraLoader
 
             while (!process.HasExited)
             {
-                if (CheckMusic.Checked && songs.Count > 0)
+                if (CheckEnableMusic.Checked && songs.Count > 0)
                 {
                     var current = songs.Where(s => s.Playing).FirstOrDefault();
 
@@ -472,7 +464,7 @@ namespace AuroraLoader
                     {
                         Invoke((MethodInvoker)delegate
                         {
-                            current.Volume = TrackVolume.Value / 10d;
+                            current.Volume = TrackMusicVolume.Value / 10d;
                         });
                     }
                 }
@@ -507,7 +499,7 @@ namespace AuroraLoader
             MessageBox.Show("Game ended.");
             ButtonSinglePlayer.Enabled = true;
             RefreshAuroraInstallData();
-            ButtonInstallOrUpdate.Enabled = true;
+            ButtonInstallOrUpdateMod.Enabled = true;
         }
 
         private void ButtonSinglePlayer_Click(object sender, EventArgs e)
@@ -559,14 +551,13 @@ namespace AuroraLoader
 
         private void CheckMusic_CheckedChanged(object sender, EventArgs e)
         {
-            if (CheckMusic.Checked)
+            if (CheckEnableMusic.Checked)
             {
-                TrackVolume.Value = 5;
-                TrackVolume.Enabled = true;
+                TrackMusicVolume.Enabled = true;
             }
             else
             {
-                TrackVolume.Enabled = false;
+                TrackMusicVolume.Enabled = false;
             }
         }
 
@@ -612,47 +603,38 @@ namespace AuroraLoader
 
         private void CheckEnableGameMod_CheckChanged(object sender, EventArgs e)
         {
-            if (CheckEnableGameMods.Checked)
+            if (CheckEnableMods.Checked)
             {
                 var result = MessageBox.Show("By using game mods you agree to not post bug reports to the official Aurora bug report channels.", "Warning!", MessageBoxButtons.OKCancel);
                 if (result == DialogResult.OK)
                 {
-                    LinkVanillaBug.Enabled = false;
-                    LinkModdedBug.Enabled = true;
+                    LinkReportBug.Enabled = false;
+                    LinkDiscord.Enabled = true;
 
-                    ComboSelectLaunchExe.Enabled = true;
+                    ComboSelectExecutableMod.Enabled = true;
                     ListDatabaseMods.Enabled = true;
-                    CheckApproved.Enabled = true;
-                    CheckPower.Enabled = true;
-                    CheckPublic.Enabled = true;
+                    CheckEnablePoweruserMods.Enabled = true;
                 }
                 else
                 {
-                    CheckEnableGameMods.Checked = false;
+                    CheckEnableMods.Checked = false;
                 }
             }
-            if (!CheckEnableGameMods.Checked)
+            if (!CheckEnableMods.Checked)
             {
-                LinkVanillaBug.Enabled = true;
-                LinkModdedBug.Enabled = false;
+                LinkReportBug.Enabled = true;
+                LinkDiscord.Enabled = false;
 
-                ComboSelectLaunchExe.SelectedItem = ComboSelectLaunchExe.Items[0];
+                ComboSelectExecutableMod.SelectedItem = ComboSelectExecutableMod.Items[0];
                 for (int i = 0; i < ListDatabaseMods.Items.Count; i++)
                 {
                     ListDatabaseMods.SetItemChecked(i, false);
                 }
 
-                ComboSelectLaunchExe.Enabled = false;
+                ComboSelectExecutableMod.Enabled = false;
                 ListDatabaseMods.Enabled = false;
-                CheckApproved.Enabled = false;
-                CheckPower.Enabled = false;
-                CheckPublic.Enabled = false;
+                CheckEnablePoweruserMods.Enabled = false;
             }
-        }
-
-        private void LabelVersion_Click(object sender, EventArgs e)
-        {
-
         }
 
         private void CheckModStatus_CheckChanged(object sender, EventArgs e)

--- a/AuroraLoader/FormMain.cs
+++ b/AuroraLoader/FormMain.cs
@@ -62,7 +62,7 @@ namespace AuroraLoader
 
         private void ButtonUpdateAurora_Click(object sender, EventArgs e)
         {
-            var result = MessageBox.Show("Updating Aurora will wipe out your saves! Are you sure you want to continue?", "Warning!", MessageBoxButtons.OKCancel);
+            var result = MessageBox.Show($"Most Aurora updates are not save-game compatible!{Environment.NewLine}We'll back up your database.{Environment.NewLine}Are you sure you want to continue?", "Warning!", MessageBoxButtons.OKCancel);
             if (result != DialogResult.OK)
             {
                 return;
@@ -71,6 +71,7 @@ namespace AuroraLoader
             try
             {
                 var installation = new GameInstallation(_auroraVersionRegistry.CurrentAuroraVersion, Program.AuroraLoaderExecutableDirectory);
+                Installer.BackupAurora(installation);
                 var thread = new Thread(() =>
                 {
                     var aurora_files = Installer.GetLatestAuroraFiles();

--- a/AuroraLoader/GameInstallation.cs
+++ b/AuroraLoader/GameInstallation.cs
@@ -8,7 +8,7 @@ namespace AuroraLoader
         public readonly string InstallationPath;
 
         // e.g. <install dir>/Aurora/1.8.0
-        public string VersionedDirectory => Path.Combine(InstallationPath, "Aurora", InstalledVersion.ToString());
+        public string VersionedDirectory => Path.Combine(InstallationPath, "Aurora", InstalledVersion.Version.ToString());
 
         public GameInstallation(AuroraVersion version, string installationPath)
         {

--- a/AuroraLoader/GameInstallation.cs
+++ b/AuroraLoader/GameInstallation.cs
@@ -1,9 +1,14 @@
-﻿namespace AuroraLoader
+﻿using System.IO;
+
+namespace AuroraLoader
 {
     public class GameInstallation
     {
         public readonly AuroraVersion InstalledVersion;
         public readonly string InstallationPath;
+
+        // e.g. <install dir>/Aurora/1.8.0
+        public string VersionedDirectory => Path.Combine(InstallationPath, "Aurora", InstalledVersion.ToString());
 
         public GameInstallation(AuroraVersion version, string installationPath)
         {

--- a/AuroraLoader/Installer.cs
+++ b/AuroraLoader/Installer.cs
@@ -43,6 +43,13 @@ namespace AuroraLoader
             Program.CopyDirectory(clean, folder);
         }
 
+        public static void BackupAurora(GameInstallation current)
+        {
+            Directory.CreateDirectory(current.VersionedDirectory);
+            File.Copy(Path.Combine(current.InstallationPath, "Aurora.exe"), Path.Combine(current.VersionedDirectory, "Aurora.exe"), true);
+            File.Copy(Path.Combine(current.InstallationPath, "AuroraDB.db"), Path.Combine(current.VersionedDirectory, "AuroraDB.db"), true);
+        }
+
         public static void UpdateAurora(GameInstallation current, Dictionary<string, string> aurora_files)
         {
             var update = SemVersion.Parse(aurora_files["Version"]);

--- a/AuroraLoader/aurora_versions.ini
+++ b/AuroraLoader/aurora_versions.ini
@@ -6,3 +6,4 @@
 1.7.2=pbVzD2
 1.7.3=GeG18n
 1.8.0=i4SLwD
+1.9.0=lrpl5w

--- a/AuroraLoader/mod.ini
+++ b/AuroraLoader/mod.ini
@@ -1,6 +1,6 @@
 ﻿Name=AuroraLoader
 Type=Exe
-Version=0.23.3
+Version=0.23.4
 AuroraVersion=1
 Status=Approved
 Exe=AuroraLoader.exe


### PR DESCRIPTION
Features:
- Reorganized UI (almost entirely cosmetic)
- Icon added to builds and re-enabled
- App startup window is now shown on top
- Added Discord link
- Aurora is backed up before updates
- Previous 4 checkboxes ('Enable mods'/'Enable approved mods'/'Enable public mods'/'Enable poweruser mods') have been replaced with two: 'Enable mods' which enables the use of approved mods, and 'Enable poweruser mods' which enables the use of poweruser mods. Utilities like A4xCalc can be used regardless.

Bugs:
- Fixed old bug in the Reddit links
- Fixed a case where the 'Update' button could be clicked when the selected mod was already up to date
- Fixed several crashes related to unknown checksums / set to 1.0.0 as last resort

![image](https://user-images.githubusercontent.com/711467/80561377-4307f380-89b2-11ea-874c-9481f19d7435.png)

[AuroraLoader-0.23.4-rc2.zip](https://github.com/Aurora-Modders/AuroraLoader/files/4549806/AuroraLoader-0.23.4-rc2.zip)