### PR TITLE
Release 0.24.0-rc4

### DIFF
--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -32,34 +32,3 @@ jobs:
       with:
         name: AuroraLoader.zip
         path: ./AuroraLoader.zip
-
-  release:
-    runs-on: ubuntu-latest
-    needs: build
-    steps:
-      - name: Download artifact
-        uses: actions/download-artifact@v1
-        with:
-          name: AuroraLoader
-      - uses: ncipollo/release-action@v1
-        if: github.event_name == 'pull_request'
-        with:
-          name: AuroraLoader ${{ github.head_ref }}
-          tag: ${{ github.head_ref }}
-          commit: ${{ github.event.after }}
-          artifacts: AuroraLoader.zip
-          artifactContentType: application/zip
-          prerelease: true
-          allowUpdates: true
-          token: ${{ secrets.GITHUB_TOKEN }}
-      - uses: ncipollo/release-action@v1
-        if: github.event_name != 'pull_request'
-        with:
-          name: AuroraLoader
-          tag: ${{ github.ref }}
-          commit: ${{ github.sha }}
-          artifacts: AuroraLoader.zip
-          artifactContentType: application/zip
-          prerelease: true
-          allowUpdates: true
-          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -26,12 +26,12 @@ jobs:
     - name: Publish
       run: dotnet publish AuroraLoader -c Release -o ./Release -p:PublishReadyToRun=true -p:PublishSingleFile=true --no-restore --self-contained false --nologo -f netcoreapp3.1 -r win-x86
     - name: "Zip"
-      run: Compress-Archive -Path ./Release/*, ./README.md -DestinationPath AuroraLoader-${{ github.head_ref }}.zip
+      run: Compress-Archive -Path ./Release/*, ./README.md -DestinationPath AuroraLoader.zip
     - name: Upload AuroraLoader artifact
       uses: actions/upload-artifact@v1
       with:
-        name: AuroraLoader
-        path: ./AuroraLoader-${{ github.head_ref }}.zip
+        name: AuroraLoader.zip
+        path: ./AuroraLoader.zip
 
   release:
     runs-on: ubuntu-latest
@@ -47,7 +47,7 @@ jobs:
           name: AuroraLoader ${{ github.head_ref }}
           tag: ${{ github.head_ref }}
           commit: ${{ github.event.after }}
-          artifacts: AuroraLoader-${{ github.head_ref }}.zip
+          artifacts: AuroraLoader.zip
           artifactContentType: application/zip
           prerelease: true
           allowUpdates: true
@@ -58,7 +58,7 @@ jobs:
           name: AuroraLoader
           tag: ${{ github.ref }}
           commit: ${{ github.sha }}
-          artifacts: "AuroraLoader.zip"
+          artifacts: AuroraLoader.zip
           artifactContentType: application/zip
           prerelease: true
           allowUpdates: true

--- a/AuroraLoader/AuroraLoader.csproj
+++ b/AuroraLoader/AuroraLoader.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
+    <RuntimeIdentifier>win-x86</RuntimeIdentifier>
     <UseWindowsForms>true</UseWindowsForms>
     <StartupObject>AuroraLoader.Program</StartupObject>
     <ApplicationIcon>Aurora.ico</ApplicationIcon>

--- a/AuroraLoader/AuroraLoader.csproj
+++ b/AuroraLoader/AuroraLoader.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-    <RuntimeIdentifier>win-x86</RuntimeIdentifier>
     <UseWindowsForms>true</UseWindowsForms>
     <StartupObject>AuroraLoader.Program</StartupObject>
     <ApplicationIcon>Aurora.ico</ApplicationIcon>

--- a/AuroraLoader/FormMain.Designer.cs
+++ b/AuroraLoader/FormMain.Designer.cs
@@ -83,10 +83,10 @@ namespace AuroraLoader
             // ButtonUpdateAurora
             // 
             this.ButtonUpdateAurora.Enabled = false;
-            this.ButtonUpdateAurora.Location = new System.Drawing.Point(625, 897);
+            this.ButtonUpdateAurora.Location = new System.Drawing.Point(605, 897);
             this.ButtonUpdateAurora.Margin = new System.Windows.Forms.Padding(6, 7, 6, 7);
             this.ButtonUpdateAurora.Name = "ButtonUpdateAurora";
-            this.ButtonUpdateAurora.Size = new System.Drawing.Size(215, 45);
+            this.ButtonUpdateAurora.Size = new System.Drawing.Size(235, 45);
             this.ButtonUpdateAurora.TabIndex = 12;
             this.ButtonUpdateAurora.Text = "Update Aurora";
             this.ButtonUpdateAurora.UseVisualStyleBackColor = true;
@@ -117,10 +117,10 @@ namespace AuroraLoader
             // 
             // ButtonUpdateAuroraLoader
             // 
-            this.ButtonUpdateAuroraLoader.Location = new System.Drawing.Point(394, 897);
+            this.ButtonUpdateAuroraLoader.Location = new System.Drawing.Point(358, 897);
             this.ButtonUpdateAuroraLoader.Margin = new System.Windows.Forms.Padding(6, 7, 6, 7);
             this.ButtonUpdateAuroraLoader.Name = "ButtonUpdateAuroraLoader";
-            this.ButtonUpdateAuroraLoader.Size = new System.Drawing.Size(215, 45);
+            this.ButtonUpdateAuroraLoader.Size = new System.Drawing.Size(235, 45);
             this.ButtonUpdateAuroraLoader.TabIndex = 12;
             this.ButtonUpdateAuroraLoader.Text = "Update Loader";
             this.ButtonUpdateAuroraLoader.UseVisualStyleBackColor = true;

--- a/AuroraLoader/FormMain.Designer.cs
+++ b/AuroraLoader/FormMain.Designer.cs
@@ -72,7 +72,7 @@ namespace AuroraLoader
             // LabelAuroraVersion
             // 
             this.LabelAuroraVersion.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.LabelAuroraVersion.Location = new System.Drawing.Point(684, 934);
+            this.LabelAuroraVersion.Location = new System.Drawing.Point(684, 969);
             this.LabelAuroraVersion.Margin = new System.Windows.Forms.Padding(6, 0, 6, 0);
             this.LabelAuroraVersion.Name = "LabelAuroraVersion";
             this.LabelAuroraVersion.Size = new System.Drawing.Size(190, 25);
@@ -83,10 +83,10 @@ namespace AuroraLoader
             // ButtonUpdateAurora
             // 
             this.ButtonUpdateAurora.Enabled = false;
-            this.ButtonUpdateAurora.Location = new System.Drawing.Point(515, 895);
+            this.ButtonUpdateAurora.Location = new System.Drawing.Point(625, 897);
             this.ButtonUpdateAurora.Margin = new System.Windows.Forms.Padding(6, 7, 6, 7);
             this.ButtonUpdateAurora.Name = "ButtonUpdateAurora";
-            this.ButtonUpdateAurora.Size = new System.Drawing.Size(170, 45);
+            this.ButtonUpdateAurora.Size = new System.Drawing.Size(215, 45);
             this.ButtonUpdateAurora.TabIndex = 12;
             this.ButtonUpdateAurora.Text = "Update Aurora";
             this.ButtonUpdateAurora.UseVisualStyleBackColor = true;
@@ -117,10 +117,10 @@ namespace AuroraLoader
             // 
             // ButtonUpdateAuroraLoader
             // 
-            this.ButtonUpdateAuroraLoader.Location = new System.Drawing.Point(328, 895);
+            this.ButtonUpdateAuroraLoader.Location = new System.Drawing.Point(394, 897);
             this.ButtonUpdateAuroraLoader.Margin = new System.Windows.Forms.Padding(6, 7, 6, 7);
             this.ButtonUpdateAuroraLoader.Name = "ButtonUpdateAuroraLoader";
-            this.ButtonUpdateAuroraLoader.Size = new System.Drawing.Size(170, 45);
+            this.ButtonUpdateAuroraLoader.Size = new System.Drawing.Size(215, 45);
             this.ButtonUpdateAuroraLoader.TabIndex = 12;
             this.ButtonUpdateAuroraLoader.Text = "Update Loader";
             this.ButtonUpdateAuroraLoader.UseVisualStyleBackColor = true;
@@ -140,13 +140,14 @@ namespace AuroraLoader
             // LabelAuroraLoaderVersion
             // 
             this.LabelAuroraLoaderVersion.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.LabelAuroraLoaderVersion.Location = new System.Drawing.Point(684, 909);
+            this.LabelAuroraLoaderVersion.Location = new System.Drawing.Point(684, 944);
             this.LabelAuroraLoaderVersion.Margin = new System.Windows.Forms.Padding(6, 0, 6, 0);
             this.LabelAuroraLoaderVersion.Name = "LabelAuroraLoaderVersion";
             this.LabelAuroraLoaderVersion.Size = new System.Drawing.Size(190, 25);
             this.LabelAuroraLoaderVersion.TabIndex = 7;
             this.LabelAuroraLoaderVersion.Text = "Loader v#.##.#";
             this.LabelAuroraLoaderVersion.TextAlign = System.Drawing.ContentAlignment.TopRight;
+            this.LabelAuroraLoaderVersion.Click += new System.EventHandler(this.LabelAuroraLoaderVersion_Click);
             // 
             // CheckEnableMods
             // 
@@ -339,7 +340,7 @@ namespace AuroraLoader
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(10F, 25F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(878, 968);
+            this.ClientSize = new System.Drawing.Size(878, 994);
             this.Controls.Add(this.ButtonMultiplayer);
             this.Controls.Add(this.LinkModSubreddit);
             this.Controls.Add(this.ManageMods);
@@ -366,7 +367,7 @@ namespace AuroraLoader
             this.Controls.Add(this.LabelAuroraVersion);
             this.Controls.Add(this.ButtonSinglePlayer);
             this.Margin = new System.Windows.Forms.Padding(6, 7, 6, 7);
-            this.MinimumSize = new System.Drawing.Size(900, 1024);
+            this.MinimumSize = new System.Drawing.Size(900, 1050);
             this.Name = "FormMain";
             this.SizeGripStyle = System.Windows.Forms.SizeGripStyle.Show;
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;

--- a/AuroraLoader/FormMain.Designer.cs
+++ b/AuroraLoader/FormMain.Designer.cs
@@ -366,7 +366,9 @@ namespace AuroraLoader
             this.Controls.Add(this.LabelAuroraVersion);
             this.Controls.Add(this.ButtonSinglePlayer);
             this.Margin = new System.Windows.Forms.Padding(6, 7, 6, 7);
+            this.MinimumSize = new System.Drawing.Size(900, 1024);
             this.Name = "FormMain";
+            this.SizeGripStyle = System.Windows.Forms.SizeGripStyle.Show;
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
             this.Text = "Aurora Loader";
             this.Load += new System.EventHandler(this.FormMain_Load);

--- a/AuroraLoader/FormMain.cs
+++ b/AuroraLoader/FormMain.cs
@@ -96,7 +96,7 @@ namespace AuroraLoader
 
         private void ButtonUpdateAuroraLoader_Click(object sender, EventArgs e)
         {
-            MessageBox.Show($"Installing AuroraLoader {_modRegistry.AuroraLoaderMod.LatestVersion}");
+            MessageBox.Show($"Installing AuroraLoader {_modRegistry.AuroraLoaderMod.LatestVersion.Version}");
             try
             {
                 var thread = new Thread(() => _modRegistry.UpdateAuroraLoader());
@@ -159,7 +159,7 @@ namespace AuroraLoader
                 var auroraLoaderMod = _modRegistry.Mods.Single(mod => mod.Name == "AuroraLoader");
                 if (auroraLoaderMod.CanBeUpdated)
                 {
-                    ButtonUpdateAuroraLoader.Text = $"Update Loader to {auroraLoaderMod.LatestVersion}";
+                    ButtonUpdateAuroraLoader.Text = $"Update Loader to {auroraLoaderMod.LatestVersion.Version}";
                     ButtonUpdateAuroraLoader.ForeColor = Color.Green;
                     ButtonUpdateAuroraLoader.Enabled = true;
 
@@ -613,6 +613,11 @@ namespace AuroraLoader
         private void LinkDiscord_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
         {
             Program.OpenBrowser(@"https://discordapp.com/channels/314031775892373504/701885084646506628");
+        }
+
+        private void LabelAuroraLoaderVersion_Click(object sender, EventArgs e)
+        {
+
         }
     }
 }

--- a/AuroraLoader/Registry/AuroraVersionRegistry.cs
+++ b/AuroraLoader/Registry/AuroraVersionRegistry.cs
@@ -87,7 +87,6 @@ namespace AuroraLoader.Registry
                     catch (Exception e)
                     {
                         Log.Error($"Didn't find an Aurora version listing at {versionsUrl}", e);
-                        throw;
                     }
                 }
                 foreach (var version in mirrorKnownVersions)

--- a/AuroraLoader/Registry/ModRegistry.cs
+++ b/AuroraLoader/Registry/ModRegistry.cs
@@ -69,12 +69,11 @@ namespace AuroraLoader.Registry
             }
         }
 
-        // Mods installed locally are identified by their mod.ini or mod.json file
-        // This is known as their 'mod configuration' file.
+        // Mods installed locally are identified by mod.json file in <root>/Mods/<ModName>
         private IList<Mod> GetLocalMods()
         {
             var mods = new List<Mod>();
-            foreach (var modJsonFile in Directory.EnumerateFiles(Program.ModDirectory, "mod.json", SearchOption.AllDirectories))
+            foreach (var modJsonFile in Directory.EnumerateFiles(Program.ModDirectory, "mod.json"))
             {
                 try
                 {

--- a/AuroraLoader/mod.json
+++ b/AuroraLoader/mod.json
@@ -40,14 +40,19 @@
         {
             // Required
             // SemVer. Version of the mod.
-            "version": "0.24.0-rc3",
+            "version": "0.24.0-rc4",
 
             // Optional (but highly encouraged)
             // Target Aurora version. May be imprecise, i.e. '1.8' targets '1.8.*'
             "target_aurora_version": "1",
 
             // Required
-            "download_url": "https://github.com/Aurora-Modders/AuroraLoader/releases/download/0.24.0/AuroraLoader.zip"
+            "download_url": "https://github.com/Aurora-Modders/AuroraLoader/releases/download/0.24.0-rc4/AuroraLoader.zip"
+        },
+        {
+            "version": "0.24.0-rc3",
+            "target_aurora_version": "1",
+            "download_url": "https://github.com/Aurora-Modders/AuroraLoader/releases/download/0.24.0-rc3/AuroraLoader.zip"
         },
         {
             "version": "0.23.5",

--- a/AuroraLoader/mod.json
+++ b/AuroraLoader/mod.json
@@ -40,7 +40,7 @@
         {
             // Required
             // SemVer. Version of the mod.
-            "version": "0.24.0",
+            "version": "0.24.0-rc3",
 
             // Optional (but highly encouraged)
             // Target Aurora version. May be imprecise, i.e. '1.8' targets '1.8.*'

--- a/updates.txt
+++ b/updates.txt
@@ -12,4 +12,4 @@
 0.23.3=https://github.com/Aurora-Modders/AuroraLoader/releases/download/0.23.3/AuroraLoader-0.23.3.zip
 0.23.4=https://github.com/Aurora-Modders/AuroraLoader/releases/download/0.23.4/AuroraLoader-0.23.4.zip
 0.23.5=https://github.com/Aurora-Modders/AuroraLoader/releases/download/0.23.5/AuroraLoader-0.23.5.zip
-0.24.0=https://github.com/Aurora-Modders/AuroraLoader/releases/download/0.24.0-rc3/AuroraLoader.zip
+0.24.0-rc4=https://github.com/Aurora-Modders/AuroraLoader/releases/download/0.24.0-rc4/AuroraLoader.zip

--- a/updates.txt
+++ b/updates.txt
@@ -12,4 +12,4 @@
 0.23.3=https://github.com/Aurora-Modders/AuroraLoader/releases/download/0.23.3/AuroraLoader-0.23.3.zip
 0.23.4=https://github.com/Aurora-Modders/AuroraLoader/releases/download/0.23.4/AuroraLoader-0.23.4.zip
 0.23.5=https://github.com/Aurora-Modders/AuroraLoader/releases/download/0.23.5/AuroraLoader-0.23.5.zip
-0.24.0=https://github.com/Aurora-Modders/AuroraLoader/releases/download/0.24.0-rc3/AuroraLoader0.24.0-rc3.zip
+0.24.0=https://github.com/Aurora-Modders/AuroraLoader/releases/download/0.24.0-rc3/AuroraLoader.zip

--- a/updates.txt
+++ b/updates.txt
@@ -12,3 +12,4 @@
 0.23.3=https://github.com/Aurora-Modders/AuroraLoader/releases/download/0.23.3/AuroraLoader-0.23.3.zip
 0.23.4=https://github.com/Aurora-Modders/AuroraLoader/releases/download/0.23.4/AuroraLoader-0.23.4.zip
 0.23.5=https://github.com/Aurora-Modders/AuroraLoader/releases/download/0.23.5/AuroraLoader-0.23.5.zip
+0.24.0=https://github.com/Aurora-Modders/AuroraLoader/releases/download/0.24.0-rc3/AuroraLoader0.24.0-rc3.zip


### PR DESCRIPTION
Bugs:
- Simplified build artifact path
- AuroraLoader update version now visible in button / fixed in some message windows
- Window size issue on some systems tentatively fixed / resize handle more visible
- Removed an unneeded error when a given mirror didn't contain Aurora version info
- Fix an issue where duplicate mod.jsons could be loaded