### PR TITLE
0.24.0-rc5

### DIFF
--- a/AuroraLoader/FormMain.cs
+++ b/AuroraLoader/FormMain.cs
@@ -57,7 +57,7 @@ namespace AuroraLoader
             _auroraVersionRegistry.Update(_modRegistry.Mirrors);
             auroraInstallation = new AuroraInstallation(_auroraVersionRegistry.CurrentAuroraVersion, Program.AuroraLoaderExecutableDirectory);
 
-            _modRegistry.Update(true, true);
+            _modRegistry.Update(true);
             RefreshAuroraInstallData();
             UpdateListViews();
             UpdateManageModsListView();
@@ -103,6 +103,7 @@ namespace AuroraLoader
                 thread.Start();
                 var progress = new FormProgress(thread);
                 progress.ShowDialog();
+                _modRegistry.AuroraLoaderMod.UpdateCache();
                 Process.Start(Path.Combine(Program.AuroraLoaderExecutableDirectory, "update_loader.bat"));
                 Application.Exit();
                 return;
@@ -372,6 +373,7 @@ namespace AuroraLoader
             Cursor = Cursors.WaitCursor;
             var mod = _modRegistry.Mods.Single(mod => mod.Name == ListManageMods.SelectedItems[0].Text);
             mod.LatestVersionCompatibleWith(_auroraVersionRegistry.CurrentAuroraVersion).Download();
+            mod.UpdateCache();
             UpdateManageModsListView();
             UpdateListViews();
             Cursor = Cursors.Default;

--- a/AuroraLoader/FormMain.cs
+++ b/AuroraLoader/FormMain.cs
@@ -293,7 +293,7 @@ namespace AuroraLoader
             ListManageMods.Columns.Add("Status");
             ListManageMods.Columns.Add("Type");
             ListManageMods.Columns.Add("Current");
-            ListManageMods.Columns.Add("Latest");
+            ListManageMods.Columns.Add("Latest Compatible");
             ListManageMods.Columns.Add("Aurora Compatibility");
             ListManageMods.Columns.Add("Description");
 
@@ -305,7 +305,7 @@ namespace AuroraLoader
                         mod.Name,
                         mod.Status.ToString(),
                         mod.Type.ToString(),
-                        mod.LatestInstalledVersion?.Version?.ToString() ?? "Not Installed",
+                        mod.LatestInstalledVersionCompatibleWith(_auroraVersionRegistry.CurrentAuroraVersion)?.Version?.ToString() ?? "Not Installed",
                         mod.LatestInstalledVersionCompatibleWith(_auroraVersionRegistry.CurrentAuroraVersion)?.Version == mod.LatestVersion?.Version
                             ? "Up to date"
                             : mod.LatestVersion?.Version?.ToString()

--- a/AuroraLoader/FormMain.cs
+++ b/AuroraLoader/FormMain.cs
@@ -158,7 +158,7 @@ namespace AuroraLoader
             try
             {
                 var auroraLoaderMod = _modRegistry.Mods.Single(mod => mod.Name == "AuroraLoader");
-                if (auroraLoaderMod.CanBeUpdated)
+                if (auroraLoaderMod.CanBeUpdated(auroraInstallation.InstalledVersion))
                 {
                     ButtonUpdateAuroraLoader.Text = $"Update Loader to {auroraLoaderMod.LatestVersion.Version}";
                     ButtonUpdateAuroraLoader.ForeColor = Color.Green;
@@ -336,7 +336,7 @@ namespace AuroraLoader
                 if (selected.Installed)
                 {
                     ButtonInstallOrUpdateMod.Text = "Update";
-                    if (selected.CanBeUpdated)
+                    if (selected.CanBeUpdated(auroraInstallation.InstalledVersion))
                     {
                         ButtonInstallOrUpdateMod.Enabled = true;
                     }

--- a/AuroraLoader/FormMain.cs
+++ b/AuroraLoader/FormMain.cs
@@ -57,7 +57,7 @@ namespace AuroraLoader
             _auroraVersionRegistry.Update(_modRegistry.Mirrors);
             auroraInstallation = new AuroraInstallation(_auroraVersionRegistry.CurrentAuroraVersion, Program.AuroraLoaderExecutableDirectory);
 
-            _modRegistry.Update(true);
+            _modRegistry.Update(_auroraVersionRegistry.CurrentAuroraVersion, true);
             RefreshAuroraInstallData();
             UpdateListViews();
             UpdateManageModsListView();

--- a/AuroraLoader/FormMain.cs
+++ b/AuroraLoader/FormMain.cs
@@ -141,7 +141,7 @@ namespace AuroraLoader
                     LabelAuroraLoaderVersion.Text = $"Loader v{_modRegistry.AuroraLoaderMod.LatestInstalledVersion.Version}";
                 }
 
-                if (_auroraVersionRegistry.CurrentAuroraVersion.Version.CompareTo(_auroraVersionRegistry.AuroraVersions.Max().Version) < 0)
+                if (_auroraVersionRegistry.CurrentAuroraVersion.Version.CompareTo(_auroraVersionRegistry.AuroraVersions.Max()?.Version) < 0)
                 {
                     ButtonUpdateAurora.Text = $"Update to {_auroraVersionRegistry.AuroraVersions.Max().Version}";
                     ButtonUpdateAurora.ForeColor = Color.Green;

--- a/AuroraLoader/Mods/Mod.cs
+++ b/AuroraLoader/Mods/Mod.cs
@@ -53,7 +53,7 @@ namespace AuroraLoader.Mods
         public bool Installed => LatestInstalledVersion != null;
         public bool CanBeUpdated(AuroraVersion auroraVersion) => LatestVersion != null
                 && LatestInstalledVersion != null
-                && LatestInstalledVersionCompatibleWith(auroraVersion).Version.CompareByPrecedence(LatestInstalledVersion.Version) > 0;
+                && LatestInstalledVersionCompatibleWith(auroraVersion).Version.CompareByPrecedence(LatestVersionCompatibleWith(auroraVersion).Version) < 0;
 
         public string ModFolder => Path.Combine(Program.ModDirectory, Name);
 

--- a/AuroraLoader/Mods/Mod.cs
+++ b/AuroraLoader/Mods/Mod.cs
@@ -30,7 +30,7 @@ namespace AuroraLoader.Mods
         public string ConfigurationFile { get; set; }
 
         [JsonPropertyName("downloads")]
-        public IList<ModVersion> Downloads { get; set; } = new List<ModVersion>();
+        public List<ModVersion> Downloads { get; set; } = new List<ModVersion>();
 
         internal Mod() { }
 

--- a/AuroraLoader/Mods/Mod.cs
+++ b/AuroraLoader/Mods/Mod.cs
@@ -51,9 +51,9 @@ namespace AuroraLoader.Mods
             .FirstOrDefault();
 
         public bool Installed => LatestInstalledVersion != null;
-        public bool CanBeUpdated => LatestVersion != null
+        public bool CanBeUpdated(AuroraVersion auroraVersion) => LatestVersion != null
                 && LatestInstalledVersion != null
-                && LatestVersion.Version.CompareByPrecedence(LatestInstalledVersion.Version) > 0;
+                && LatestInstalledVersionCompatibleWith(auroraVersion).Version.CompareByPrecedence(LatestInstalledVersion.Version) > 0;
 
         public string ModFolder => Path.Combine(Program.ModDirectory, Name);
 

--- a/AuroraLoader/Registry/ModRegistry.cs
+++ b/AuroraLoader/Registry/ModRegistry.cs
@@ -45,9 +45,7 @@ namespace AuroraLoader.Registry
                 var existingMod = mods.SingleOrDefault(mod => mod.Name == remoteMod.Name);
                 if (existingMod != null)
                 {
-                    var updatedDownloadList = existingMod.Downloads.ToList();
-                    updatedDownloadList.AddRange(remoteMod.Downloads.Where(nd => !existingMod.Downloads.Any(ed => ed.Version == nd.Version)));
-                    existingMod.Downloads = updatedDownloadList;
+                    existingMod = remoteMod;
                 }
                 else
                 {

--- a/AuroraLoader/Registry/ModRegistry.cs
+++ b/AuroraLoader/Registry/ModRegistry.cs
@@ -29,7 +29,7 @@ namespace AuroraLoader.Registry
             Mirrors = ModConfigurationReader.GetMirrorsFromIni(_configuration);
         }
 
-        public void Update(bool updateRemote = false, bool updateCache = false)
+        public void Update(AuroraVersion version, bool updateRemote = false, bool updateCache = false)
         {
             Log.Debug($"Updating mod registry, updateRemote={updateRemote} updateCache={updateCache}");
 
@@ -56,6 +56,12 @@ namespace AuroraLoader.Registry
                     mods.Add(remoteMod);
                 }
             }
+
+            foreach (var mod in mods)
+            {
+                mod.Downloads.RemoveAll(d => !version.CompatibleWith(d.TargetAuroraVersion));
+            }
+
             Mods = mods;
 
             if (updateRemote && updateCache)

--- a/AuroraLoader/Registry/ModRegistry.cs
+++ b/AuroraLoader/Registry/ModRegistry.cs
@@ -57,9 +57,13 @@ namespace AuroraLoader.Registry
                 }
             }
 
-            foreach (var mod in mods)
+            foreach (var mod in mods.ToList())
             {
                 mod.Downloads.RemoveAll(d => !version.CompatibleWith(d.TargetAuroraVersion));
+                if (mod.Downloads.Count == 0)
+                {
+                    mods.Remove(mod);
+                }
             }
 
             Mods = mods;

--- a/AuroraLoader/mod.json
+++ b/AuroraLoader/mod.json
@@ -35,36 +35,40 @@
     // Point to your mod's repository, forum, AAR, etc
     "url": "https://github.com/Aurora-Modders/AuroraLoader",
 
-    "downloads": 
-    [
-        {
-            // Required
-            // SemVer. Version of the mod.
-            "version": "0.24.0-rc4",
+  "downloads": [
+    {
+      // Required
+      // SemVer. Version of the mod.
+      "version": "0.24.0-rc5",
 
-            // Optional (but highly encouraged)
-            // Target Aurora version. May be imprecise, i.e. '1.8' targets '1.8.*'
-            "target_aurora_version": "1",
+      // Optional (but highly encouraged)
+      // Target Aurora version. May be imprecise, i.e. '1.8' targets '1.8.*'
+      "target_aurora_version": "1",
 
-            // Required
-            "download_url": "https://github.com/Aurora-Modders/AuroraLoader/releases/download/0.24.0-rc4/AuroraLoader.zip"
-        },
-        {
-            "version": "0.24.0-rc3",
-            "target_aurora_version": "1",
-            "download_url": "https://github.com/Aurora-Modders/AuroraLoader/releases/download/0.24.0-rc3/AuroraLoader.zip"
-        },
-        {
-            "version": "0.23.5",
-            "target_aurora_version": "1",
-            "download_url": "https://github.com/Aurora-Modders/AuroraLoader/releases/download/0.23.5/AuroraLoader-0.23.5.zip"
-        },
+      // Required
+      "download_url": "https://github.com/Aurora-Modders/AuroraLoader/releases/download/0.24.0-rc5/AuroraLoader.zip"
+    },
+    {
+      "version": "0.24.0-rc4",
+      "target_aurora_version": "1",
+      "download_url": "https://github.com/Aurora-Modders/AuroraLoader/releases/download/0.24.0-rc4/AuroraLoader.zip"
+    },
+    {
+      "version": "0.24.0-rc3",
+      "target_aurora_version": "1",
+      "download_url": "https://github.com/Aurora-Modders/AuroraLoader/releases/download/0.24.0-rc3/AuroraLoader.zip"
+    },
+    {
+      "version": "0.23.5",
+      "target_aurora_version": "1",
+      "download_url": "https://github.com/Aurora-Modders/AuroraLoader/releases/download/0.23.5/AuroraLoader-0.23.5.zip"
+    },
 
-        // Order is not important
-        {
-            "version": "0.23.4",
-            "target_aurora_version": "1",
-            "download_url": "https://github.com/Aurora-Modders/AuroraLoader/releases/download/0.23.5/AuroraLoader-0.23.5.zip"
-        }
-    ]
+    // Order is not important
+    {
+      "version": "0.23.4",
+      "target_aurora_version": "1",
+      "download_url": "https://github.com/Aurora-Modders/AuroraLoader/releases/download/0.23.5/AuroraLoader-0.23.5.zip"
+    }
+  ]
 }


### PR DESCRIPTION
Bugs:
- Tweak cache update behavior
- Harden cached Aurora version handling
- Stop displaying incompatible mod versions that may be in the registry
- Fix crash on launch when registry cannot be contacted
- Fix issue allowing mods to be updated to incompatible versions
- Fix mod version CanBeUpdated property