### PR TITLE
0.25.3

### DIFF
--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Publish
       run: dotnet publish AuroraLoader -c Release -o ./Release -p:PublishReadyToRun=true -p:PublishSingleFile=true --no-restore --self-contained false --nologo -f netcoreapp3.1 -r win-x86
     - name: "Zip"
-      run: Compress-Archive -Path "./Release/*", "./README.md" -DestinationPath "AuroraLoader-$(git rev-parse --short=5 ${{ github.sha }}).zip"
+      run: Compress-Archive -Path "./Release/*", "./README.md", "./CHANGELOG.md" -DestinationPath "AuroraLoader-$(git rev-parse --short=5 ${{ github.sha }}).zip"
     - name: Upload AuroraLoader artifact
       uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -30,5 +30,4 @@ jobs:
     - name: Upload AuroraLoader artifact
       uses: actions/upload-artifact@v1
       with:
-        name: AuroraLoader-${GITHUB_SHA::8}.zip
         path: ./AuroraLoader-${GITHUB_SHA::8}.zip

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -16,7 +16,7 @@ jobs:
       with:
         dotnet-version: 3.1.300
       env:
-        DOTNET_NOLOGO: true
+        DOTNET_NOLOGO: 1
     - run: dotnet test
     - name: Build and publish
       run: dotnet publish AuroraLoader --no-restore --self-contained true -f netcoreapp3.1 -r win-x86 -o ./Release -p:PublishReadyToRun=true -p:PublishSingleFile=true

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -23,16 +23,10 @@ jobs:
       run: dotnet build --configuration Release --no-restore
     - name: Test
       run: dotnet test --no-restore --verbosity normal
-    - name: Publish
-      run: dotnet publish AuroraLoader -c Release -o ./Release -p:PublishReadyToRun=true -p:PublishSingleFile=true --no-restore --self-contained false --nologo -f netcoreapp3.1 -r win-x86
-    - name: get shortsha
-      id: vars
-      run: |
-        echo ::set-output name=sha_short::$(git rev-parse --short=5 ${{ github.sha }})
     - name: "Zip"
       env:
         SHA: ${{ steps.vars.outputs.sha_short }}
-      run: Compress-Archive -Path ./Release/*, ./README.md -DestinationPath AuroraLoader-$($env:SHA).zip
+      run: Compress-Archive -Path ./Release/*, ./README.md -DestinationPath AuroraLoader-$($(git rev-parse --short=5 ${{ github.sha }})).zip
     - name: Upload AuroraLoader artifact
       uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -26,9 +26,9 @@ jobs:
     - name: Publish
       run: dotnet publish AuroraLoader -c Release -o ./Release -p:PublishReadyToRun=true -p:PublishSingleFile=true --no-restore --self-contained false --nologo -f netcoreapp3.1 -r win-x86
     - name: "Zip"
-      run: Compress-Archive -Path ./Release/*, ./README.md -DestinationPath AuroraLoader.zip
+      run: Compress-Archive -Path ./Release/*, ./README.md -DestinationPath AuroraLoader-${GITHUB_SHA::8}.zip
     - name: Upload AuroraLoader artifact
       uses: actions/upload-artifact@v1
       with:
-        name: AuroraLoader.zip
-        path: ./AuroraLoader.zip
+        name: AuroraLoader-${GITHUB_SHA::8}.zip
+        path: ./AuroraLoader-${GITHUB_SHA::8}.zip

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Test
       run: dotnet test --no-restore --verbosity normal
     - name: "Zip"
-      run: Compress-Archive -Path ./Release/*, ./README.md -DestinationPath AuroraLoader-$(git rev-parse --short=5 ${{ github.sha }}).zip
+      run: Compress-Archive -Path "./Release/*", "./README.md" -DestinationPath "AuroraLoader-$(git rev-parse --short=5 ${{ github.sha }}).zip"
     - name: Upload AuroraLoader artifact
       uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -28,6 +28,6 @@ jobs:
     - name: "Zip"
       run: Compress-Archive -Path ./Release/*, ./README.md -DestinationPath AuroraLoader-${GITHUB_SHA::8}.zip
     - name: Upload AuroraLoader artifact
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v2
       with:
         path: ./AuroraLoader-${GITHUB_SHA::8}.zip

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -16,8 +16,12 @@ jobs:
       with:
         dotnet-version: 3.1.300
       env:
-        DOTNET_NOLOGO: 1
+        DOTNET_NOLOGO: true
+        DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
     - run: dotnet test
+      env:
+        DOTNET_NOLOGO: true
+        DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
     - name: Build and publish
       run: dotnet publish AuroraLoader --no-restore --self-contained true -f netcoreapp3.1 -r win-x86 -o ./Release -p:PublishReadyToRun=true -p:PublishSingleFile=true
     - name: Upload artifact

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -25,9 +25,15 @@ jobs:
       run: dotnet test --no-restore --verbosity normal
     - name: Publish
       run: dotnet publish AuroraLoader -c Release -o ./Release -p:PublishReadyToRun=true -p:PublishSingleFile=true --no-restore --self-contained false --nologo -f netcoreapp3.1 -r win-x86
+    - name: get shortsha
+      id: vars
+      run: |
+        echo ::set-output name=sha_short::$(git rev-parse --short=5 ${{ github.sha }})
     - name: "Zip"
-      run: Compress-Archive -Path ./Release/*, ./README.md -DestinationPath AuroraLoader-${{GITHUB_SHA::8}}.zip
+      env:
+        SHA: ${{ steps.vars.outputs.sha_short }}
+      run: Compress-Archive -Path ./Release/*, ./README.md -DestinationPath AuroraLoader-$SHA.zip
     - name: Upload AuroraLoader artifact
       uses: actions/upload-artifact@v2
       with:
-        path: ./AuroraLoader-${{GITHUB_SHA::8}}.zip
+        path: ./AuroraLoader*.zip

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -14,7 +14,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 3.1.x
+        dotnet-version: '3.1.x'
     - run: dotnet test
     - name: Build and publish
       run: dotnet publish AuroraLoader --no-restore --self-contained true --nologo -f netcoreapp3.1 -r win-x86 -o ./Release -p:PublishReadyToRun=true -p:PublishSingleFile=true

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 3.1.4
+        dotnet-version: 3.1.300
     - name: Install dependencies
       run: dotnet restore
     - name: Build

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -8,20 +8,17 @@ on:
 
 jobs:
   build:
-
     runs-on: windows-latest
 
     steps:
     - uses: actions/checkout@v2
-    - name: Setup .NET Core
-      uses: actions/setup-dotnet@v1
+    - uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 3.1.300
-    - name: Test
-      run: dotnet test
-    - name: Build and Publish
+        dotnet-version: 3.1.x
+    - run: dotnet test
+    - name: Build and publish
       run: dotnet publish AuroraLoader --no-restore --self-contained true --nologo -f netcoreapp3.1 -r win-x86 -o ./Release -p:PublishReadyToRun=true -p:PublishSingleFile=true
-    - name: Upload AuroraLoader artifact
+    - name: Upload artifact
       uses: actions/upload-artifact@v2
       with:
         path: ./Release/*

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -23,6 +23,8 @@ jobs:
       run: dotnet build --configuration Release --no-restore
     - name: Test
       run: dotnet test --no-restore --verbosity normal
+    - name: Publish
+      run: dotnet publish AuroraLoader -c Release -o ./Release -p:PublishReadyToRun=true -p:PublishSingleFile=true --no-restore --self-contained false --nologo -f netcoreapp3.1 -r win-x86
     - name: "Zip"
       run: Compress-Archive -Path "./Release/*", "./README.md" -DestinationPath "AuroraLoader-$(git rev-parse --short=5 ${{ github.sha }}).zip"
     - name: Upload AuroraLoader artifact

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -14,10 +14,12 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: '3.1.x'
+        dotnet-version: 3.1.300
+      env:
+        DOTNET_NOLOGO: true
     - run: dotnet test
     - name: Build and publish
-      run: dotnet publish AuroraLoader --no-restore --self-contained true --nologo -f netcoreapp3.1 -r win-x86 -o ./Release -p:PublishReadyToRun=true -p:PublishSingleFile=true
+      run: dotnet publish AuroraLoader --no-restore --self-contained true -f netcoreapp3.1 -r win-x86 -o ./Release -p:PublishReadyToRun=true -p:PublishSingleFile=true
     - name: Upload artifact
       uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Test
       run: dotnet test --no-restore --verbosity normal
     - name: Publish
-      run: dotnet publish AuroraLoader -c Release -o ./Release -p:PublishReadyToRun=true -p:PublishSingleFile=true --no-restore --self-contained false --nologo -f netcoreapp3.1 -r win-x86
+      run: dotnet publish AuroraLoader -c Release -o ./Release -p:PublishReadyToRun=true -p:PublishSingleFile=true --no-restore --self-contained true --nologo -f netcoreapp3.1 -r win-x86
     - name: "Zip"
       run: Compress-Archive -Path "./Release/*", "./README.md", "./CHANGELOG.md" -DestinationPath "AuroraLoader-$(git rev-parse --short=5 ${{ github.sha }}).zip"
     - name: Upload AuroraLoader artifact

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -15,13 +15,7 @@ jobs:
     - uses: actions/setup-dotnet@v1
       with:
         dotnet-version: 3.1.300
-      env:
-        DOTNET_NOLOGO: true
-        DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
     - run: dotnet test
-      env:
-        DOTNET_NOLOGO: true
-        DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
     - name: Build and publish
       run: dotnet publish AuroraLoader --no-restore --self-contained true -f netcoreapp3.1 -r win-x86 -o ./Release -p:PublishReadyToRun=true -p:PublishSingleFile=true
     - name: Upload artifact

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -24,9 +24,7 @@ jobs:
     - name: Test
       run: dotnet test --no-restore --verbosity normal
     - name: "Zip"
-      env:
-        SHA: ${{ steps.vars.outputs.sha_short }}
-      run: Compress-Archive -Path ./Release/*, ./README.md -DestinationPath AuroraLoader-$($(git rev-parse --short=5 ${{ github.sha }})).zip
+      run: Compress-Archive -Path ./Release/*, ./README.md -DestinationPath AuroraLoader-$(git rev-parse --short=5 ${{ github.sha }}).zip
     - name: Upload AuroraLoader artifact
       uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 3.1.101
+        dotnet-version: 3.1.4
     - name: Install dependencies
       run: dotnet restore
     - name: Build
@@ -32,7 +32,7 @@ jobs:
     - name: "Zip"
       env:
         SHA: ${{ steps.vars.outputs.sha_short }}
-      run: Compress-Archive -Path ./Release/*, ./README.md -DestinationPath AuroraLoader-$SHA.zip
+      run: Compress-Archive -Path ./Release/*, ./README.md -DestinationPath AuroraLoader-$($env:SHA).zip
     - name: Upload AuroraLoader artifact
       uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -17,17 +17,17 @@ jobs:
       uses: actions/setup-dotnet@v1
       with:
         dotnet-version: 3.1.300
-    - name: Install dependencies
-      run: dotnet restore
-    - name: Build
-      run: dotnet build --configuration Release --no-restore
     - name: Test
-      run: dotnet test --no-restore --verbosity normal
-    - name: Publish
-      run: dotnet publish AuroraLoader -c Release -o ./Release -p:PublishReadyToRun=true -p:PublishSingleFile=true --no-restore --self-contained true --nologo -f netcoreapp3.1 -r win-x86
-    - name: "Zip"
-      run: Compress-Archive -Path "./Release/*", "./README.md", "./CHANGELOG.md" -DestinationPath "AuroraLoader-$(git rev-parse --short=5 ${{ github.sha }}).zip"
+      run: dotnet test
+    - name: Build and Publish
+      run: dotnet publish AuroraLoader --no-restore --self-contained true --nologo -f netcoreapp3.1 -r win-x86 -o ./Release -p:PublishReadyToRun=true -p:PublishSingleFile=true
     - name: Upload AuroraLoader artifact
       uses: actions/upload-artifact@v2
       with:
-        path: ./AuroraLoader*.zip
+        path: ./Release/*
+    - uses: actions/upload-artifact@v2
+      with:
+        path: ./README.md
+    - uses: actions/upload-artifact@v2
+      with:
+        path: ./CHANGELOG.md

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -26,8 +26,8 @@ jobs:
     - name: Publish
       run: dotnet publish AuroraLoader -c Release -o ./Release -p:PublishReadyToRun=true -p:PublishSingleFile=true --no-restore --self-contained false --nologo -f netcoreapp3.1 -r win-x86
     - name: "Zip"
-      run: Compress-Archive -Path ./Release/*, ./README.md -DestinationPath AuroraLoader-${GITHUB_SHA::8}.zip
+      run: Compress-Archive -Path ./Release/*, ./README.md -DestinationPath AuroraLoader-${{GITHUB_SHA::8}}.zip
     - name: Upload AuroraLoader artifact
       uses: actions/upload-artifact@v2
       with:
-        path: ./AuroraLoader-${GITHUB_SHA::8}.zip
+        path: ./AuroraLoader-${{GITHUB_SHA::8}}.zip

--- a/AuroraLoader/AuroraInstallation.cs
+++ b/AuroraLoader/AuroraInstallation.cs
@@ -1,13 +1,11 @@
-﻿using System;
+﻿using AuroraLoader.Mods;
+using Semver;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Runtime.CompilerServices;
-using System.Windows.Forms;
-using AuroraLoader.Mods;
-using AuroraLoader.Registry;
-using Semver;
 [assembly: InternalsVisibleTo("AuroraLoaderTest")]
 
 namespace AuroraLoader

--- a/AuroraLoader/AuroraLoader.csproj
+++ b/AuroraLoader/AuroraLoader.csproj
@@ -101,6 +101,10 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <ExcludeFromSingleFile>true</ExcludeFromSingleFile>
     </None>
+    <None Update="..\CHANGELOG.md">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <ExcludeFromSingleFile>true</ExcludeFromSingleFile>
+    </None>
     <None Update="update_loader.bat">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <ExcludeFromSingleFile>true</ExcludeFromSingleFile>

--- a/AuroraLoader/FormMain.Designer.cs
+++ b/AuroraLoader/FormMain.Designer.cs
@@ -289,7 +289,7 @@ namespace AuroraLoader
             this.SelectedSavelabel.Name = "SelectedSavelabel";
             this.SelectedSavelabel.Size = new System.Drawing.Size(72, 15);
             this.SelectedSavelabel.TabIndex = 42;
-            this.SelectedSavelabel.Text = "Game: XXXX";
+            this.SelectedSavelabel.Text = "No game selected";
             // 
             // ButtonMangeSaves
             // 

--- a/AuroraLoader/FormMain.Designer.cs
+++ b/AuroraLoader/FormMain.Designer.cs
@@ -36,6 +36,7 @@ namespace AuroraLoader
             this.TrackMusicVolume = new System.Windows.Forms.TrackBar();
             this.CheckEnableMusic = new System.Windows.Forms.CheckBox();
             this.ButtonReadme = new System.Windows.Forms.Button();
+            this.ButtonChangelog = new System.Windows.Forms.Button();
             this.LabelAuroraLoaderVersion = new System.Windows.Forms.Label();
             this.CheckEnableMods = new System.Windows.Forms.CheckBox();
             this.CheckEnablePoweruserMods = new System.Windows.Forms.CheckBox();
@@ -108,7 +109,7 @@ namespace AuroraLoader
             // 
             // ButtonReadme
             // 
-            this.ButtonReadme.Location = new System.Drawing.Point(495, 12);
+            this.ButtonReadme.Location = new System.Drawing.Point(395, 12);
             this.ButtonReadme.Margin = new System.Windows.Forms.Padding(4);
             this.ButtonReadme.Name = "ButtonReadme";
             this.ButtonReadme.Size = new System.Drawing.Size(84, 24);
@@ -117,6 +118,17 @@ namespace AuroraLoader
             this.ButtonReadme.UseVisualStyleBackColor = true;
             this.ButtonReadme.Click += new System.EventHandler(this.ButtonReadme_Click);
             // 
+            // ButtonChangelog
+            //
+            this.ButtonChangelog.Location = new System.Drawing.Point(495, 12);
+            this.ButtonChangelog.Margin = new System.Windows.Forms.Padding(4);
+            this.ButtonChangelog.Name = "ButtonChangelog";
+            this.ButtonChangelog.Size = new System.Drawing.Size(84, 24);
+            this.ButtonChangelog.TabIndex = 14;
+            this.ButtonChangelog.Text = "Changelog";
+            this.ButtonChangelog.UseVisualStyleBackColor = true;
+            this.ButtonChangelog.Click += new System.EventHandler(this.ButtonChangelog_Click);
+            //
             // LabelAuroraLoaderVersion
             // 
             this.LabelAuroraLoaderVersion.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
@@ -336,6 +348,7 @@ namespace AuroraLoader
             this.Controls.Add(this.CheckEnableMods);
             this.Controls.Add(this.LabelAuroraLoaderVersion);
             this.Controls.Add(this.ButtonReadme);
+            this.Controls.Add(this.ButtonChangelog);
             this.Controls.Add(this.CheckEnableMusic);
             this.Controls.Add(this.TrackMusicVolume);
             this.Controls.Add(this.LabelAuroraVersion);
@@ -361,6 +374,7 @@ namespace AuroraLoader
         private System.Windows.Forms.TrackBar TrackMusicVolume;
         private System.Windows.Forms.CheckBox CheckEnableMusic;
         private System.Windows.Forms.Button ButtonReadme;
+        private System.Windows.Forms.Button ButtonChangelog;
         private System.Windows.Forms.Label LabelAuroraLoaderVersion;
         private System.Windows.Forms.CheckBox CheckEnableMods;
         private System.Windows.Forms.CheckBox CheckEnablePoweruserMods;

--- a/AuroraLoader/FormMain.Designer.cs
+++ b/AuroraLoader/FormMain.Designer.cs
@@ -127,7 +127,6 @@ namespace AuroraLoader
             this.LabelAuroraLoaderVersion.TabIndex = 7;
             this.LabelAuroraLoaderVersion.Text = "Loader v#.##.#";
             this.LabelAuroraLoaderVersion.TextAlign = System.Drawing.ContentAlignment.TopRight;
-            this.LabelAuroraLoaderVersion.Click += new System.EventHandler(this.LabelAuroraLoaderVersion_Click);
             // 
             // CheckEnableMods
             // 
@@ -288,7 +287,7 @@ namespace AuroraLoader
             this.ButtonMangeSaves.TabIndex = 41;
             this.ButtonMangeSaves.Text = "Select Game";
             this.ButtonMangeSaves.UseVisualStyleBackColor = true;
-            this.ButtonMangeSaves.Click += new System.EventHandler(this.ButtonMangeSaves_Click);
+            this.ButtonMangeSaves.Click += new System.EventHandler(this.ButtonManageSaves_Click);
             // 
             // PictureBoxUpdateAurora
             // 

--- a/AuroraLoader/FormMain.cs
+++ b/AuroraLoader/FormMain.cs
@@ -45,6 +45,7 @@ namespace AuroraLoader
                 Log.Debug("Failed to load icon");
             }
 
+            _ = MessageBox.Show(new Form { TopMost = true }, "AuroraLoader will check for updates and then launch, this might take a moment.");
             Cursor = Cursors.WaitCursor;
 
             CheckEnableMods.Enabled = true;

--- a/AuroraLoader/FormMain.cs
+++ b/AuroraLoader/FormMain.cs
@@ -502,13 +502,13 @@ namespace AuroraLoader
 
         private void ButtonManageMods_Click(object sender, EventArgs e)
         {
-            UpdateListViews();
             if (_modManagementWindow != null)
             {
                 _modManagementWindow.Close();
             }
             _modManagementWindow = new FormModDownload(_configuration);
-            _modManagementWindow.Show();
+            _modManagementWindow.ShowDialog();
+            UpdateListViews();
         }
 
         private void ButtonManageSaves_Click(object sender, EventArgs e)
@@ -537,7 +537,7 @@ namespace AuroraLoader
             }
             else
             {
-                SelectedSavelabel.Text = "Game: XXXX";
+                SelectedSavelabel.Text = "No game selected";
                 ButtonSinglePlayer.Enabled = false;
             }
         }

--- a/AuroraLoader/FormMain.cs
+++ b/AuroraLoader/FormMain.cs
@@ -85,7 +85,7 @@ namespace AuroraLoader
                 var progress = new FormProgress(thread) { Text = "Updating Aurora" };
                 progress.ShowDialog();
                 RefreshAuroraInstallData();
-                MessageBox.Show($"Update complete - you can now start new games using Aurora {_auroraVersionRegistry.CurrentAuroraVersion}!");
+                MessageBox.Show($"Update complete - you can now start new games using Aurora {_auroraVersionRegistry.CurrentAuroraVersion.Version}!");
             }
             catch (Exception ecp)
             {
@@ -148,13 +148,8 @@ namespace AuroraLoader
             }
             else
             {
-                // If a game is loaded, show the version of Aurora that game targets
-                if (auroraInstallation.InstalledVersion != null && auroraInstallation?.InstalledVersion != _auroraVersionRegistry.CurrentAuroraVersion)
-                {
-                    LabelAuroraVersion.Text = $"Aurora v{auroraInstallation.InstalledVersion.Version} ({auroraInstallation.InstalledVersion.Checksum})";
-                }
                 // Show only the checksum if we can't identify the version of Aurora
-                else if (_auroraVersionRegistry.CurrentAuroraVersion.Version == SemVersion.Parse("1.0.0"))
+                if (_auroraVersionRegistry.CurrentAuroraVersion.Version == SemVersion.Parse("1.0.0"))
                 {
                     LabelAuroraVersion.Text = $"Aurora.exe ({_auroraVersionRegistry.CurrentAuroraVersion.Checksum})";
                 }
@@ -500,7 +495,7 @@ namespace AuroraLoader
                 UpdateListViews();
                 RefreshAuroraInstallData();
 
-                SelectedSavelabel.Text = "Game: " + name;
+                SelectedSavelabel.Text = $"Game: {name} (Aurora v{auroraInstallation.InstalledVersion.Version})";
                 ButtonSinglePlayer.Enabled = true;
             }
             else

--- a/AuroraLoader/FormMain.cs
+++ b/AuroraLoader/FormMain.cs
@@ -217,6 +217,7 @@ namespace AuroraLoader
                 && mod.LatestInstalledVersionCompatibleWith(auroraInstallation.InstalledVersion) != null)
                 .Select(mod => mod.Name).ToArray());
 
+            string currentlySelectedExecutableModName = (string)ComboSelectExecutableMod.SelectedItem;
             ComboSelectExecutableMod.Items.Clear();
             ComboSelectExecutableMod.Items.Add("Base game");
 
@@ -227,7 +228,11 @@ namespace AuroraLoader
             {
                 ComboSelectExecutableMod.Items.Add(mod.Name);
             }
-            if (ComboSelectExecutableMod.Items.Count > 0)
+            if (!string.IsNullOrWhiteSpace(currentlySelectedExecutableModName) && ComboSelectExecutableMod.Items.Contains(currentlySelectedExecutableModName))
+            {
+                ComboSelectExecutableMod.SelectedIndex = ComboSelectExecutableMod.Items.IndexOf(currentlySelectedExecutableModName);
+            }
+            else if (ComboSelectExecutableMod.Items.Count > 0)
             {
                 ComboSelectExecutableMod.SelectedIndex = 0;
             }

--- a/AuroraLoader/FormMain.cs
+++ b/AuroraLoader/FormMain.cs
@@ -64,8 +64,6 @@ namespace AuroraLoader
             Cursor = Cursors.Default;
         }
 
-
-
         private void UpdateAurora()
         {
             var dialog = MessageBox.Show($"Aurora version {_auroraVersionRegistry.AuroraVersions.Max()?.Version} available. Update?", "Update Aurora", MessageBoxButtons.YesNo);
@@ -87,6 +85,7 @@ namespace AuroraLoader
                 var progress = new FormProgress(thread) { Text = "Updating Aurora" };
                 progress.ShowDialog();
                 RefreshAuroraInstallData();
+                MessageBox.Show($"Update complete - you can now start new games using Aurora {_auroraVersionRegistry.CurrentAuroraVersion}!");
             }
             catch (Exception ecp)
             {
@@ -149,7 +148,13 @@ namespace AuroraLoader
             }
             else
             {
-                if (_auroraVersionRegistry.CurrentAuroraVersion.Version == SemVersion.Parse("1.0.0"))
+                // If a game is loaded, show the version of Aurora that game targets
+                if (auroraInstallation.InstalledVersion != null && auroraInstallation?.InstalledVersion != _auroraVersionRegistry.CurrentAuroraVersion)
+                {
+                    LabelAuroraVersion.Text = $"Aurora v{auroraInstallation.InstalledVersion.Version} ({auroraInstallation.InstalledVersion.Checksum})";
+                }
+                // Show only the checksum if we can't identify the version of Aurora
+                else if (_auroraVersionRegistry.CurrentAuroraVersion.Version == SemVersion.Parse("1.0.0"))
                 {
                     LabelAuroraVersion.Text = $"Aurora.exe ({_auroraVersionRegistry.CurrentAuroraVersion.Checksum})";
                 }
@@ -285,9 +290,6 @@ namespace AuroraLoader
         {
             UpdateListViews();
         }
-
-
-
 
         private void ButtonSinglePlayer_Click(object sender, EventArgs e)
         {
@@ -465,11 +467,6 @@ namespace AuroraLoader
             Program.OpenBrowser(@"https://discordapp.com/channels/314031775892373504/701885084646506628");
         }
 
-        private void LabelAuroraLoaderVersion_Click(object sender, EventArgs e)
-        {
-
-        }
-
         private void ButtonManageMods_Click(object sender, EventArgs e)
         {
             UpdateListViews();
@@ -481,13 +478,13 @@ namespace AuroraLoader
             _modManagementWindow.Show();
         }
 
-        private void ButtonMangeSaves_Click(object sender, EventArgs e)
+        private void ButtonManageSaves_Click(object sender, EventArgs e)
         {
             if (_saveManagementWindow != null)
             {
                 _saveManagementWindow.Close();
             }
-            _saveManagementWindow = new FormSaves();
+            _saveManagementWindow = new FormSaves(auroraInstallation);
             _saveManagementWindow.ShowDialog();
 
             var name = _saveManagementWindow.Game;
@@ -500,6 +497,7 @@ namespace AuroraLoader
                 auroraInstallation = new AuroraInstallation(version, Path.GetDirectoryName(exe));
 
                 UpdateListViews();
+                RefreshAuroraInstallData();
 
                 SelectedSavelabel.Text = "Game: " + name;
                 ButtonSinglePlayer.Enabled = true;

--- a/AuroraLoader/FormMain.cs
+++ b/AuroraLoader/FormMain.cs
@@ -158,6 +158,7 @@ namespace AuroraLoader
                 {
                     LabelAuroraVersion.Text = $"Aurora.exe ({_auroraVersionRegistry.CurrentAuroraVersion.Checksum})";
                 }
+                // Default to showing the most recent installed Aurora version
                 else
                 {
                     LabelAuroraVersion.Text = $"Aurora v{_auroraVersionRegistry.CurrentAuroraVersion.Version} ({_auroraVersionRegistry.CurrentAuroraVersion.Checksum})";

--- a/AuroraLoader/FormMain.cs
+++ b/AuroraLoader/FormMain.cs
@@ -122,7 +122,7 @@ namespace AuroraLoader
             PictureBoxUpdateAurora.Visible = update;
             if (update == true)
             {
-                var dialog = MessageBox.Show($"Aurora version {_auroraVersionRegistry.AuroraVersions.Max()?.Version} avalilbe, Update?", "Update Aurora", MessageBoxButtons.YesNo);
+                var dialog = MessageBox.Show($"Aurora version {_auroraVersionRegistry.AuroraVersions.Max()?.Version} available, Update?", "Update Aurora", MessageBoxButtons.YesNo);
                 if (dialog == DialogResult.Yes)
                 {
                     UpdateAurora();
@@ -137,7 +137,7 @@ namespace AuroraLoader
             PictureBoxUpdateLoader.Visible = update;
             if (update == true)
             {
-                var dialog = MessageBox.Show($"Loader version {_modRegistry.AuroraLoaderMod.LatestVersion.Version} avalilbe, Update?", "Update Loader", MessageBoxButtons.YesNo);
+                var dialog = MessageBox.Show($"Loader version {_modRegistry.AuroraLoaderMod.LatestVersion.Version} available, Update?", "Update Loader", MessageBoxButtons.YesNo);
                 if (dialog == DialogResult.Yes)
                 {
                     UpdateLoader();
@@ -482,7 +482,7 @@ namespace AuroraLoader
         private void ButtonManageMods_Click(object sender, EventArgs e)
         {
             UpdateListViews();
-            if(_modMangementWindow != null) 
+            if(_modMangementWindow != null)
             {
                 _modMangementWindow.Close();
             }

--- a/AuroraLoader/FormMain.cs
+++ b/AuroraLoader/FormMain.cs
@@ -45,8 +45,6 @@ namespace AuroraLoader
                 Log.Debug("Failed to load icon");
             }
 
-            // Show message on top
-            _ = MessageBox.Show(new Form { TopMost = true }, "AuroraLoader will check for updates and then launch, this might take a moment.");
             Cursor = Cursors.WaitCursor;
 
             CheckEnableMods.Enabled = true;

--- a/AuroraLoader/FormMain.cs
+++ b/AuroraLoader/FormMain.cs
@@ -70,6 +70,12 @@ namespace AuroraLoader
 
         private void UpdateAurora()
         {
+            var dialog = MessageBox.Show($"Aurora version {_auroraVersionRegistry.AuroraVersions.Max()?.Version} available, Update?", "Update Aurora", MessageBoxButtons.YesNo);
+            if (dialog != DialogResult.Yes)
+            {
+                return;
+            }
+
             try
             {
                 var thread = new Thread(() =>
@@ -93,7 +99,12 @@ namespace AuroraLoader
 
         private void UpdateLoader()
         {
-            MessageBox.Show($"Installing AuroraLoader {_modRegistry.AuroraLoaderMod.LatestVersion.Version}");
+            var dialog = MessageBox.Show($"AuroraLoader version {_modRegistry.AuroraLoaderMod.LatestVersion.Version} available, Update?", "Update Loader", MessageBoxButtons.YesNo);
+            if (dialog != DialogResult.Yes)
+            {
+                return;
+            }
+
             try
             {
                 var thread = new Thread(() => _modRegistry.UpdateAuroraLoader());
@@ -116,34 +127,16 @@ namespace AuroraLoader
 
         private void ButtonUpdateAurora_Click(object sender, EventArgs e) { UpdateAurora(); }
 
-        private void AuroraUpdateUI(bool update)
+        private void SetCanUpdateAurora(bool update)
         {
             PictureBoxUpdateAurora.Enabled = update;
             PictureBoxUpdateAurora.Visible = update;
-            if (update == true)
-            {
-                var dialog = MessageBox.Show($"Aurora version {_auroraVersionRegistry.AuroraVersions.Max()?.Version} available, Update?", "Update Aurora", MessageBoxButtons.YesNo);
-                if (dialog == DialogResult.Yes)
-                {
-                    UpdateAurora();
-                }
-            }
-
         }
 
-        private void LoaderUpdateUI(bool update)
+        private void SetCanUpdateLoader(bool update)
         {
             PictureBoxUpdateLoader.Enabled = update;
             PictureBoxUpdateLoader.Visible = update;
-            if (update == true)
-            {
-                var dialog = MessageBox.Show($"Loader version {_modRegistry.AuroraLoaderMod.LatestVersion.Version} available, Update?", "Update Loader", MessageBoxButtons.YesNo);
-                if (dialog == DialogResult.Yes)
-                {
-                    UpdateLoader();
-                }
-                else { }
-            }
         }
 
         /// <summary>
@@ -174,11 +167,11 @@ namespace AuroraLoader
 
                 if (_auroraVersionRegistry.CurrentAuroraVersion.Version.CompareTo(_auroraVersionRegistry.AuroraVersions.Max()?.Version) < 0)
                 {
-                    AuroraUpdateUI(true);
+                    SetCanUpdateAurora(true);
                 }
                 else
                 {
-                    AuroraUpdateUI(false);
+                    SetCanUpdateAurora(false);
                 }
             }
 
@@ -187,13 +180,13 @@ namespace AuroraLoader
                 var auroraLoaderMod = _modRegistry.Mods.Single(mod => mod.Name == "AuroraLoader");
                 if (auroraLoaderMod.CanBeUpdated(auroraInstallation.InstalledVersion))
                 {
-                    LoaderUpdateUI(true);
+                    SetCanUpdateLoader(true);
 
-                    AuroraUpdateUI(false);
+                    SetCanUpdateAurora(false);
                 }
                 else
                 {
-                    LoaderUpdateUI(false);
+                    SetCanUpdateLoader(false);
                 }
             }
             catch (Exception exc)
@@ -329,8 +322,8 @@ namespace AuroraLoader
             }
 
             ButtonSinglePlayer.Enabled = false;
-            LoaderUpdateUI(false);
-            AuroraUpdateUI(false);
+            SetCanUpdateLoader(false);
+            SetCanUpdateAurora(false);
 
             var modVersions = _modRegistry.Mods.Where(mod =>
             (ListDatabaseMods.CheckedItems != null && ListDatabaseMods.CheckedItems.Contains(mod.Name))

--- a/AuroraLoader/FormMain.cs
+++ b/AuroraLoader/FormMain.cs
@@ -435,7 +435,38 @@ namespace AuroraLoader
 
         private void ButtonReadme_Click(object sender, EventArgs e)
         {
-            Program.OpenBrowser("https://github.com/Aurora-Modders/AuroraLoader/blob/master/README.md");
+            if (File.Exists(Path.Combine(Program.AuroraLoaderExecutableDirectory, "README.md")))
+            {
+                Process.Start(new ProcessStartInfo()
+                {
+                    WorkingDirectory = Program.AuroraLoaderExecutableDirectory,
+                    FileName = "README.md",
+                    UseShellExecute = true,
+                    CreateNoWindow = true
+                });
+            }
+            else
+            {
+                Program.OpenBrowser("https://github.com/Aurora-Modders/AuroraLoader/blob/master/README.md");
+            }
+        }
+
+        private void ButtonChangelog_Click(object sender, EventArgs e)
+        {
+            if (File.Exists(Path.Combine(Program.AuroraLoaderExecutableDirectory, "CHANGELOG.md")))
+            {
+                Process.Start(new ProcessStartInfo()
+                {
+                    WorkingDirectory = Program.AuroraLoaderExecutableDirectory,
+                    FileName = "CHANGELOG.md",
+                    UseShellExecute = true,
+                    CreateNoWindow = true
+                });
+            }
+            else
+            {
+                Program.OpenBrowser("https://github.com/Aurora-Modders/AuroraLoader/blob/master/CHANGELOG.md");
+            }
         }
 
         private void LinkModSubreddit_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)

--- a/AuroraLoader/FormMain.cs
+++ b/AuroraLoader/FormMain.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿using AuroraLoader.Mods;
+using AuroraLoader.Registry;
+using Microsoft.Extensions.Configuration;
+using Semver;
+using System;
 using System.Collections.Generic;
 using System.Data;
 using System.Diagnostics;
@@ -7,10 +11,6 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Windows.Forms;
-using AuroraLoader.Mods;
-using AuroraLoader.Registry;
-using Microsoft.Extensions.Configuration;
-using Semver;
 
 namespace AuroraLoader
 {
@@ -520,7 +520,7 @@ namespace AuroraLoader
             _saveManagementWindow = new FormSaves(auroraInstallation);
             _saveManagementWindow.ShowDialog();
 
-            var name = _saveManagementWindow.Game;
+            var name = _saveManagementWindow.SelectedGameName;
             if (name != null)
             {
                 var exe = Path.Combine(Program.AuroraLoaderExecutableDirectory, "Games", name, "Aurora.exe");

--- a/AuroraLoader/FormMain.cs
+++ b/AuroraLoader/FormMain.cs
@@ -23,8 +23,8 @@ namespace AuroraLoader
         private readonly AuroraVersionRegistry _auroraVersionRegistry;
         private readonly ModRegistry _modRegistry;
 
-        private FormModDownload _modMangementWindow;
-        private FormSaves _saveMangementWindow;
+        private FormModDownload _modManagementWindow;
+        private FormSaves _saveManagementWindow;
 
         public FormMain(IConfiguration configuration, AuroraVersionRegistry auroraVersionRegistry, ModRegistry modRegistry)
         {
@@ -473,24 +473,24 @@ namespace AuroraLoader
         private void ButtonManageMods_Click(object sender, EventArgs e)
         {
             UpdateListViews();
-            if(_modMangementWindow != null)
+            if (_modManagementWindow != null)
             {
-                _modMangementWindow.Close();
+                _modManagementWindow.Close();
             }
-            _modMangementWindow = new FormModDownload(_configuration);
-            _modMangementWindow.Show();
+            _modManagementWindow = new FormModDownload(_configuration);
+            _modManagementWindow.Show();
         }
 
         private void ButtonMangeSaves_Click(object sender, EventArgs e)
         {
-            if (_saveMangementWindow != null)
+            if (_saveManagementWindow != null)
             {
-                _saveMangementWindow.Close();
+                _saveManagementWindow.Close();
             }
-            _saveMangementWindow = new FormSaves();
-            _saveMangementWindow.ShowDialog();
+            _saveManagementWindow = new FormSaves();
+            _saveManagementWindow.ShowDialog();
 
-            var name = _saveMangementWindow.Game;
+            var name = _saveManagementWindow.Game;
             if (name != null)
             {
                 var exe = Path.Combine(Program.AuroraLoaderExecutableDirectory, "Games", name, "Aurora.exe");

--- a/AuroraLoader/FormMain.cs
+++ b/AuroraLoader/FormMain.cs
@@ -70,7 +70,7 @@ namespace AuroraLoader
 
         private void UpdateAurora()
         {
-            var dialog = MessageBox.Show($"Aurora version {_auroraVersionRegistry.AuroraVersions.Max()?.Version} available, Update?", "Update Aurora", MessageBoxButtons.YesNo);
+            var dialog = MessageBox.Show($"Aurora version {_auroraVersionRegistry.AuroraVersions.Max()?.Version} available. Update?", "Update Aurora", MessageBoxButtons.YesNo);
             if (dialog != DialogResult.Yes)
             {
                 return;
@@ -99,7 +99,7 @@ namespace AuroraLoader
 
         private void UpdateLoader()
         {
-            var dialog = MessageBox.Show($"AuroraLoader version {_modRegistry.AuroraLoaderMod.LatestVersion.Version} available, Update?", "Update Loader", MessageBoxButtons.YesNo);
+            var dialog = MessageBox.Show($"AuroraLoader version {_modRegistry.AuroraLoaderMod.LatestVersion.Version} available. Update?", "Update Loader", MessageBoxButtons.YesNo);
             if (dialog != DialogResult.Yes)
             {
                 return;

--- a/AuroraLoader/FormMain.cs
+++ b/AuroraLoader/FormMain.cs
@@ -66,7 +66,7 @@ namespace AuroraLoader
 
         private void UpdateAurora()
         {
-            var dialog = MessageBox.Show($"Aurora version {_auroraVersionRegistry.AuroraVersions.Max()?.Version} available. Update?", "Update Aurora", MessageBoxButtons.YesNo);
+            var dialog = MessageBox.Show($"Aurora v{_auroraVersionRegistry.AuroraVersions.Max()?.Version} is available. Download now? This is safe and won't affect your existing games.", "Download new Aurora version", MessageBoxButtons.YesNo);
             if (dialog != DialogResult.Yes)
             {
                 return;

--- a/AuroraLoader/FormModDownload.Designer.cs
+++ b/AuroraLoader/FormModDownload.Designer.cs
@@ -31,6 +31,7 @@
             this.ManageModslabel = new System.Windows.Forms.Label();
             this.ListViewRegistryMods = new System.Windows.Forms.ListView();
             this.ButtonGetMod = new System.Windows.Forms.Button();
+            this.ButtonChangelog = new System.Windows.Forms.Button();
             this.ButtonConfigMod = new System.Windows.Forms.Button();
             this.RichTextBoxDescription = new System.Windows.Forms.RichTextBox();
             this.SuspendLayout();
@@ -63,9 +64,9 @@
             this.ButtonGetMod.Text = "Install";
             this.ButtonGetMod.UseVisualStyleBackColor = true;
             this.ButtonGetMod.Click += new System.EventHandler(this.ButtonGetMod_Click);
-            // 
+            //
             // ButtonConfigMod
-            // 
+            //
             this.ButtonConfigMod.Location = new System.Drawing.Point(112, 307);
             this.ButtonConfigMod.Name = "ButtonConfigMod";
             this.ButtonConfigMod.Size = new System.Drawing.Size(94, 27);
@@ -73,6 +74,16 @@
             this.ButtonConfigMod.Text = "Configure";
             this.ButtonConfigMod.UseVisualStyleBackColor = true;
             this.ButtonConfigMod.Click += new System.EventHandler(this.ButtonConfigMod_Click);
+            //
+            // ButtonChangelog
+            //
+            this.ButtonChangelog.Location = new System.Drawing.Point(212, 307);
+            this.ButtonChangelog.Name = "ButtonChangelog";
+            this.ButtonChangelog.Size = new System.Drawing.Size(94, 27);
+            this.ButtonChangelog.TabIndex = 31;
+            this.ButtonChangelog.Text = "Changelog";
+            this.ButtonChangelog.UseVisualStyleBackColor = true;
+            this.ButtonChangelog.Click += new System.EventHandler(this.ButtonChangelog_Click);
             // 
             // RichTextBoxDescription
             // 
@@ -89,6 +100,7 @@
             this.ClientSize = new System.Drawing.Size(614, 346);
             this.Controls.Add(this.RichTextBoxDescription);
             this.Controls.Add(this.ButtonConfigMod);
+            this.Controls.Add(this.ButtonChangelog);
             this.Controls.Add(this.ButtonGetMod);
             this.Controls.Add(this.ListViewRegistryMods);
             this.Controls.Add(this.ManageModslabel);
@@ -107,6 +119,7 @@
         private System.Windows.Forms.ListView ListViewRegistryMods;
         private System.Windows.Forms.Button ButtonGetMod;
         private System.Windows.Forms.Button ButtonConfigMod;
+        private System.Windows.Forms.Button ButtonChangelog;
         private System.Windows.Forms.RichTextBox RichTextBoxDescription;
     }
 }

--- a/AuroraLoader/FormModDownload.cs
+++ b/AuroraLoader/FormModDownload.cs
@@ -1,19 +1,10 @@
-﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Data;
-using System.Drawing;
-using System.Text;
-
+﻿using AuroraLoader.Registry;
+using Microsoft.Extensions.Configuration;
+using System;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using System.Diagnostics;
 using System.Windows.Forms;
-
-using Microsoft.Extensions.Configuration;
-
-using AuroraLoader.Mods;
-using AuroraLoader.Registry;
 
 namespace AuroraLoader
 {

--- a/AuroraLoader/FormModDownload.cs
+++ b/AuroraLoader/FormModDownload.cs
@@ -55,11 +55,11 @@ namespace AuroraLoader
                     {
                         ButtonGetMod.Enabled = true;
                     }
-                    if (selected.ConfigurationFile != null)
+                    if (selected.Installed && selected.ConfigurationFile != null)
                     {
                         ButtonConfigMod.Enabled = true;
                     }
-                    if (selected.ChangelogFile != null)
+                    if (selected.Installed && selected.ChangelogFile != null)
                     {
                         ButtonChangelog.Enabled = true;
                     }

--- a/AuroraLoader/FormSaves.Designer.cs
+++ b/AuroraLoader/FormSaves.Designer.cs
@@ -46,10 +46,9 @@
             this.ListViewSaves.TabIndex = 0;
             this.ListViewSaves.UseCompatibleStateImageBehavior = false;
             this.ListViewSaves.View = System.Windows.Forms.View.List;
-            this.ListViewSaves.SelectedIndexChanged += new System.EventHandler(this.ListViewSaves_SelectedIndexChanged);
-            // 
+            //
             // LabelSave
-            // 
+            //
             this.LabelSave.AutoSize = true;
             this.LabelSave.Location = new System.Drawing.Point(12, 9);
             this.LabelSave.Name = "LabelSave";
@@ -76,10 +75,9 @@
             this.ButtonResetSaves.TabIndex = 3;
             this.ButtonResetSaves.Text = "Reset";
             this.ButtonResetSaves.UseVisualStyleBackColor = true;
-            this.ButtonResetSaves.Click += new System.EventHandler(this.ButtonResetSaves_Click);
-            // 
+            //
             // ButtonNewGame
-            // 
+            //
             this.ButtonNewGame.Location = new System.Drawing.Point(174, 232);
             this.ButtonNewGame.Name = "ButtonNewGame";
             this.ButtonNewGame.Size = new System.Drawing.Size(75, 23);

--- a/AuroraLoader/FormSaves.Designer.cs
+++ b/AuroraLoader/FormSaves.Designer.cs
@@ -86,6 +86,7 @@
             this.ButtonNewGame.TabIndex = 4;
             this.ButtonNewGame.Text = "New Game";
             this.ButtonNewGame.UseVisualStyleBackColor = true;
+            this.ButtonNewGame.Enabled = false;
             this.ButtonNewGame.Click += new System.EventHandler(this.ButtonNewGame_Click);
             // 
             // TextNewGame
@@ -94,7 +95,8 @@
             this.TextNewGame.Name = "TextNewGame";
             this.TextNewGame.Size = new System.Drawing.Size(328, 23);
             this.TextNewGame.TabIndex = 5;
-            this.TextNewGame.Text = "New game name";
+            this.TextNewGame.PlaceholderText = "New game name";
+            this.TextNewGame.TextChanged += new System.EventHandler(this.TextNewGame_Changed);
             // 
             // FormSaves
             // 

--- a/AuroraLoader/FormSaves.cs
+++ b/AuroraLoader/FormSaves.cs
@@ -44,7 +44,7 @@ namespace AuroraLoader
 
         private void TextNewGame_Changed(object sender, EventArgs e)
         {
-            if (!string.IsNullOrEmpty(TextNewGame.Text))
+            if (!string.IsNullOrWhiteSpace(TextNewGame.Text))
             {
                 ButtonNewGame.Enabled = true;
             }

--- a/AuroraLoader/FormSaves.cs
+++ b/AuroraLoader/FormSaves.cs
@@ -66,7 +66,7 @@ namespace AuroraLoader
 
         private void ButtonNewGame_Click(object sender, EventArgs e)
         {
-            var dialog = MessageBox.Show($"Create a new game in a fresh Aurora {_auroraInstallation.InstalledVersion} database called '{TextNewGame.Text}'?", "Create New Game", MessageBoxButtons.YesNo);
+            var dialog = MessageBox.Show($"Create a new game in a fresh Aurora {_auroraInstallation.InstalledVersion.Version} database called '{TextNewGame.Text}'?", "Create New Game", MessageBoxButtons.YesNo);
             if (dialog != DialogResult.Yes)
             {
                 return;

--- a/AuroraLoader/FormSaves.cs
+++ b/AuroraLoader/FormSaves.cs
@@ -40,32 +40,42 @@ namespace AuroraLoader
 
         }
 
-        private void ButtonNewGame_Click(object sender, EventArgs e)
+        private void TextNewGame_Changed(object sender, EventArgs e)
         {
-            var name = TextNewGame.Text;
-            var dialog = MessageBox.Show($"Create a new game in a fresh database called '{name}'?", "Create New Game", MessageBoxButtons.YesNo);
-            if (dialog != DialogResult.Yes)
+            if (!string.IsNullOrEmpty(TextNewGame.Text))
             {
-                return;
+                ButtonNewGame.Enabled = true;
+            }
+            else
+            {
+                ButtonNewGame.Enabled = false;
             }
 
             for (int i = 0; i < ListViewSaves.Items.Count; i++)
             {
                 var item = ListViewSaves.Items[i];
-                if (item.Text == name)
+                if (item.Text == TextNewGame.Text)
                 {
-                    MessageBox.Show("A game with that name already exists.");
-                    return;
+                    ButtonNewGame.Enabled = false;
+                    break;
                 }
+            }
+        }
+
+        private void ButtonNewGame_Click(object sender, EventArgs e)
+        {
+            var dialog = MessageBox.Show($"Create a new game in a fresh database called '{TextNewGame.Text}'?", "Create New Game", MessageBoxButtons.YesNo);
+            if (dialog != DialogResult.Yes)
+            {
+                return;
             }
 
             Cursor = Cursors.WaitCursor;
 
-
-            var folder = Path.Combine(Program.AuroraLoaderExecutableDirectory, "Games", name);
+            var folder = Path.Combine(Program.AuroraLoaderExecutableDirectory, "Games", TextNewGame.Text);
             Installer.CopyClean(folder);
             UpdateList();
-
+            TextNewGame.Text = null;
             Cursor = Cursors.Default;
         }
 

--- a/AuroraLoader/FormSaves.cs
+++ b/AuroraLoader/FormSaves.cs
@@ -13,10 +13,12 @@ namespace AuroraLoader
     public partial class FormSaves : Form
     {
         internal string Game { get; private set; } = null;
+        private AuroraInstallation _auroraInstallation;
 
-        public FormSaves()
+        public FormSaves(AuroraInstallation auroraInstallation)
         {
             InitializeComponent();
+            _auroraInstallation = auroraInstallation;
         }
 
         private void FormSaves_Load(object sender, EventArgs e)
@@ -64,7 +66,7 @@ namespace AuroraLoader
 
         private void ButtonNewGame_Click(object sender, EventArgs e)
         {
-            var dialog = MessageBox.Show($"Create a new game in a fresh database called '{TextNewGame.Text}'?", "Create New Game", MessageBoxButtons.YesNo);
+            var dialog = MessageBox.Show($"Create a new game in a fresh Aurora {_auroraInstallation.InstalledVersion} database called '{TextNewGame.Text}'?", "Create New Game", MessageBoxButtons.YesNo);
             if (dialog != DialogResult.Yes)
             {
                 return;

--- a/AuroraLoader/FormSaves.cs
+++ b/AuroraLoader/FormSaves.cs
@@ -43,6 +43,12 @@ namespace AuroraLoader
         private void ButtonNewGame_Click(object sender, EventArgs e)
         {
             var name = TextNewGame.Text;
+            var dialog = MessageBox.Show($"Create a new game in a fresh database called '{name}'?", "Create New Game", MessageBoxButtons.YesNo);
+            if (dialog != DialogResult.Yes)
+            {
+                return;
+            }
+
             for (int i = 0; i < ListViewSaves.Items.Count; i++)
             {
                 var item = ListViewSaves.Items[i];
@@ -55,7 +61,7 @@ namespace AuroraLoader
 
             Cursor = Cursors.WaitCursor;
 
-            
+
             var folder = Path.Combine(Program.AuroraLoaderExecutableDirectory, "Games", name);
             Installer.CopyClean(folder);
             UpdateList();

--- a/AuroraLoader/FormSaves.cs
+++ b/AuroraLoader/FormSaves.cs
@@ -1,19 +1,16 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.ComponentModel;
 using System.Data;
-using System.Drawing;
 using System.IO;
 using System.Linq;
-using System.Text;
 using System.Windows.Forms;
 
 namespace AuroraLoader
 {
     public partial class FormSaves : Form
     {
-        internal string Game { get; private set; } = null;
-        private AuroraInstallation _auroraInstallation;
+        internal string SelectedGameName { get; private set; } = null;
+        private readonly AuroraInstallation _auroraInstallation;
 
         public FormSaves(AuroraInstallation auroraInstallation)
         {
@@ -26,20 +23,10 @@ namespace AuroraLoader
             UpdateList();
         }
 
-        private void ListViewSaves_SelectedIndexChanged(object sender, EventArgs e)
-        {
-
-        }
-
         private void ButtonLoadSaves_Click(object sender, EventArgs e)
         {
-            Game = ListViewSaves.SelectedItems[0].Text;
+            SelectedGameName = ListViewSaves.SelectedItems[0].Text;
             Close();
-        }
-
-        private void ButtonResetSaves_Click(object sender, EventArgs e)
-        {
-
         }
 
         private void TextNewGame_Changed(object sender, EventArgs e)

--- a/AuroraLoader/Installer.cs
+++ b/AuroraLoader/Installer.cs
@@ -1,13 +1,11 @@
-﻿using System;
+﻿using AuroraLoader.Mods;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
 using System.Net;
 using System.Windows.Forms;
-using System.Windows.Forms.Design;
-using AuroraLoader.Mods;
-using Semver;
 
 namespace AuroraLoader
 {

--- a/AuroraLoader/Mods/JsonConverters.cs
+++ b/AuroraLoader/Mods/JsonConverters.cs
@@ -1,7 +1,7 @@
-﻿using System;
+﻿using Semver;
+using System;
 using System.Text.Json;
 using System.Text.Json.Serialization;
-using Semver;
 
 namespace AuroraLoader.Mods
 {

--- a/AuroraLoader/Mods/Mod.cs
+++ b/AuroraLoader/Mods/Mod.cs
@@ -29,6 +29,9 @@ namespace AuroraLoader.Mods
         [JsonPropertyName("configuration_file")]
         public string ConfigurationFile { get; set; }
 
+        [JsonPropertyName("changelog_file")]
+        public string ChangelogFile { get; set; }
+
         [JsonPropertyName("downloads")]
         public List<ModVersion> Downloads { get; set; } = new List<ModVersion>();
 

--- a/AuroraLoader/Mods/ModConfigurationReader.cs
+++ b/AuroraLoader/Mods/ModConfigurationReader.cs
@@ -1,9 +1,8 @@
-﻿using System;
+﻿using Semver;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using Microsoft.Extensions.Configuration;
-using Semver;
 
 namespace AuroraLoader.Mods
 {
@@ -15,7 +14,7 @@ namespace AuroraLoader.Mods
             return settings.Select(kvp => new AuroraVersion(SemVersion.Parse(kvp.Key), kvp.Value));
         }
 
-        public static IList<string> GetMirrorsFromIni(IConfiguration configuration)
+        public static IList<string> GetMirrorsFromIni()
         {
             var mirrors = new List<string>();
             try

--- a/AuroraLoader/Mods/ModVersion.cs
+++ b/AuroraLoader/Mods/ModVersion.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿using Microsoft.Data.Sqlite;
+using Semver;
+using System;
 using System.Diagnostics;
 using System.IO;
 using System.IO.Compression;
@@ -6,8 +8,6 @@ using System.Linq;
 using System.Net;
 using System.Text.Json.Serialization;
 using System.Windows.Forms;
-using Microsoft.Data.Sqlite;
-using Semver;
 
 namespace AuroraLoader.Mods
 {

--- a/AuroraLoader/Program.cs
+++ b/AuroraLoader/Program.cs
@@ -1,3 +1,6 @@
+using AuroraLoader.Mods;
+using AuroraLoader.Registry;
+using Microsoft.Extensions.Configuration;
 using System;
 using System.Diagnostics;
 using System.IO;
@@ -5,9 +8,6 @@ using System.Runtime.InteropServices;
 using System.Security.Cryptography;
 using System.Threading;
 using System.Windows.Forms;
-using AuroraLoader.Mods;
-using AuroraLoader.Registry;
-using Microsoft.Extensions.Configuration;
 
 namespace AuroraLoader
 {

--- a/AuroraLoader/Registry/AuroraVersion.cs
+++ b/AuroraLoader/Registry/AuroraVersion.cs
@@ -1,6 +1,6 @@
-﻿using System;
-using AuroraLoader.Mods;
+﻿using AuroraLoader.Mods;
 using Semver;
+using System;
 
 namespace AuroraLoader
 {

--- a/AuroraLoader/Registry/AuroraVersionRegistry.cs
+++ b/AuroraLoader/Registry/AuroraVersionRegistry.cs
@@ -1,12 +1,11 @@
-﻿using System;
+﻿using AuroraLoader.Mods;
+using Microsoft.Extensions.Configuration;
+using Semver;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Net;
-using System.Security.Cryptography;
-using AuroraLoader.Mods;
-using Microsoft.Extensions.Configuration;
-using Semver;
 
 namespace AuroraLoader.Registry
 {
@@ -33,12 +32,12 @@ namespace AuroraLoader.Registry
             {
                 throw new Exception($"Aurora version cache not found at {_versionCachePath} and no mirrors provided");
             }
-            
+
             if (File.Exists(_versionCachePath))
             {
                 UpdateKnownVersionsFromCache();
             }
-            
+
             if (mirrors != null)
             {
                 UpdateKnownAuroraVersionsFromMirrors(mirrors);

--- a/AuroraLoader/Registry/ModRegistry.cs
+++ b/AuroraLoader/Registry/ModRegistry.cs
@@ -1,11 +1,11 @@
-﻿using System;
+﻿using AuroraLoader.Mods;
+using Microsoft.Extensions.Configuration;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Net;
 using System.Text.Json;
-using AuroraLoader.Mods;
-using Microsoft.Extensions.Configuration;
 
 namespace AuroraLoader.Registry
 {
@@ -26,7 +26,7 @@ namespace AuroraLoader.Registry
         public ModRegistry(IConfiguration configuration)
         {
             _configuration = configuration;
-            Mirrors = ModConfigurationReader.GetMirrorsFromIni(_configuration);
+            Mirrors = ModConfigurationReader.GetMirrorsFromIni();
         }
 
         public void Update(AuroraVersion version, bool updateRemote = false, bool updateCache = false)

--- a/AuroraLoader/Song.cs
+++ b/AuroraLoader/Song.cs
@@ -1,5 +1,5 @@
-﻿using System;
-using NAudio.Wave;
+﻿using NAudio.Wave;
+using System;
 
 namespace AuroraLoader
 {

--- a/AuroraLoader/mod.json
+++ b/AuroraLoader/mod.json
@@ -28,7 +28,6 @@
     "configuration_file": "mod.json",
 
     // Optional
-    // Not yet implemented
     "changelog_file": "",
 
     // Optional
@@ -36,52 +35,37 @@
     "url": "https://github.com/Aurora-Modders/AuroraLoader",
 
   "downloads": [
+    // Order is not important
     {
       // Required
       // SemVer. Version of the mod.
-      "version": "0.25.2",
+      "version": "0.25.3",
 
       // Optional (but highly encouraged)
       // Target Aurora version. May be imprecise, i.e. '1.8' targets '1.8.*'
       "target_aurora_version": "1",
 
       // Required
+      "download_url": "https://github.com/Aurora-Modders/AuroraLoader/releases/download/0.25.3/AuroraLoader.zip"
+    },
+    {
+      "version": "0.25.2",
+      "target_aurora_version": "1",
       "download_url": "https://github.com/Aurora-Modders/AuroraLoader/releases/download/0.25.2/AuroraLoader.zip"
     },
     {
-      // Required
-      // SemVer. Version of the mod.
       "version": "0.25.1",
-
-      // Optional (but highly encouraged)
-      // Target Aurora version. May be imprecise, i.e. '1.8' targets '1.8.*'
       "target_aurora_version": "1",
-
-      // Required
       "download_url": "https://github.com/Aurora-Modders/AuroraLoader/releases/download/0.25.1/AuroraLoader.zip"
     },
     {
-      // Required
-      // SemVer. Version of the mod.
       "version": "0.25.0",
-
-      // Optional (but highly encouraged)
-      // Target Aurora version. May be imprecise, i.e. '1.8' targets '1.8.*'
       "target_aurora_version": "1",
-
-      // Required
       "download_url": "https://github.com/Aurora-Modders/AuroraLoader/releases/download/0.25.0/AuroraLoader.zip"
     },
     {
-      // Required
-      // SemVer. Version of the mod.
       "version": "0.24.0",
-
-      // Optional (but highly encouraged)
-      // Target Aurora version. May be imprecise, i.e. '1.8' targets '1.8.*'
       "target_aurora_version": "1",
-
-      // Required
       "download_url": "https://github.com/Aurora-Modders/AuroraLoader/releases/download/0.24.0/AuroraLoader.zip"
     },
     {
@@ -89,7 +73,6 @@
       "target_aurora_version": "1",
       "download_url": "https://github.com/Aurora-Modders/AuroraLoader/releases/download/0.23.5/AuroraLoader-0.23.5.zip"
     },
-    // Order is not important
     {
       "version": "0.23.4",
       "target_aurora_version": "1",

--- a/AuroraLoader/mod.json
+++ b/AuroraLoader/mod.json
@@ -28,7 +28,7 @@
     "configuration_file": "mod.json",
 
     // Optional
-    "changelog_file": "",
+    "changelog_file": "CHANGELOG.md",
 
     // Optional
     // Point to your mod's repository, forum, AAR, etc

--- a/AuroraLoader/mod.json
+++ b/AuroraLoader/mod.json
@@ -39,14 +39,14 @@
     {
       // Required
       // SemVer. Version of the mod.
-      "version": "0.25.3",
+      "version": "0.25.3-rc1",
 
       // Optional (but highly encouraged)
       // Target Aurora version. May be imprecise, i.e. '1.8' targets '1.8.*'
       "target_aurora_version": "1",
 
       // Required
-      "download_url": "https://github.com/Aurora-Modders/AuroraLoader/releases/download/0.25.3/AuroraLoader.zip"
+      "download_url": "https://github.com/Aurora-Modders/AuroraLoader/releases/download/0.25.3-rc1/AuroraLoader.zip"
     },
     {
       "version": "0.25.2",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@
 - `mod.json` and AuroraLoader now support changelog files (there's a Changelog button next to the Config File button in the mod manager now)
 - Aurora version targeted by the currently loaded game is shown in parenthesis (and only mods compatible with the loaded game's version are shown - but that was already the case)
 - Additional message after updating Aurora telling user to create a new game in order to use the new version
-- Got rid of the modal dialog on launch, AuroraLoader opens snappily enough
 - Got rid of modal dialogs prompting user to update Aurora/the loader on launch (there are a lot of cases where people want to hang back at 1.9.5 and I don't want to annoy them - IMHO the snazzy new update icons are obvious enough). This also means that the dialogs aren't re-shown every time `RefreshInstallData()` is called.
 - Behavior when creating new save games is a bit more intuitive (the 'new game' button is disabled when it can't be clicked, and the user is presented with a confirmation dialog before creating a fresh DB that tells them the version of Aurora that the new game will target - in later Loader versions, we may allow them to select this manually)
 - (Devs) GitHub Action now builds the loader on the LTS version of .NET Core 3.1 and appends the built commit to the artifact's name

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,101 @@
+# Changelog
+
+## [0.25.3]
+
+### Changes
+- `mod.json` and AuroraLoader now support changelog files (there's a Changelog button next to the Config File button in the mod manager now)
+- Aurora version targeted by the currently loaded game is shown in parenthesis (and only mods compatible with the loaded game's version are shown - but that was already the case)
+- Additional message after updating Aurora telling user to create a new game in order to use the new version
+- Got rid of the modal dialog on launch, AuroraLoader opens snappily enough
+- Got rid of modal dialogs prompting user to update Aurora/the loader on launch (there are a lot of cases where people want to hang back at 1.9.5 and I don't want to annoy them - IMHO the snazzy new update icons are obvious enough). This also means that the dialogs aren't re-shown every time `RefreshInstallData()` is called.
+- Behavior when creating new save games is a bit more intuitive (the 'new game' button is disabled when it can't be clicked, and the user is presented with a confirmation dialog before creating a fresh DB that tells them the version of Aurora that the new game will target - in later Loader versions, we may allow them to select this manually)
+- (Devs) GitHub Action now builds the loader on the LTS version of .NET Core 3.1 and appends the built commit to the artifact's name
+
+### Bugfixes
+- Buttons for opening a mod's config & changelog files are disabled if the mod hasn't actually been installed yet
+- Fixed typo in Aurora & loader update confirmation dialogs
+- Confirmation dialogs are now shown when the user decides to manually update either Aurora or the loader (previously behavior was inconsistent)
+- Removed an unused click handler & fixed some typos in the codebase
+
+[AuroraLoader-096cd.zip](https://github.com/Aurora-Modders/AuroraLoader/files/4693370/AuroraLoader-096cd.zip)
+
+## [0.25.2]
+
+### Bugfixes
+- Dependency and packaging tweaks
+
+## [0.25.1]
+
+### Bugfixes
+
+- uninstall & close utilities on game end
+- fix theme mod installation
+- fix update aurora
+
+## [0.25.0]
+
+### Features
+
+- UI overhaul by agm-114. Mod and game management extracted to separate windows.
+- Support single-folder-per-game
+
+### Bugfixes
+
+- Throw exception when mod.json in root doesn't belong to AuroraLoader
+- Fix 'airplane mode'
+
+## [0.24.0]
+
+### Features
+- `mod.json` format (see example in this PR) - this should make things much more intuitive for mod authors. Individual mod versions are now first-class citizens in the backend.
+- Aurora backed up to a versioned directory immediately on load & before updates
+- Mod approval status and description now displayed in manage listview
+- Some UI features should be slightly more responsive (i.e. more intelligent updates)
+- Improve postgame player motivation
+- Mod compatibility status made clearer / wildcards added
+
+### Bugfixes
+- AuroraLoader update version now visible in button / fixed in some message windows
+- Window resize handle more visible
+- Removed an unneeded error when a given mirror didn't contain Aurora version info
+- Fixed an issue where duplicate mod.jsons could be loaded
+- Tweaked cache update behavior
+- Hardened cached Aurora version handling
+- Stop peddisplaying incompatible mod versions that may be in the registry
+- Fixed crash on launch when registry cannot be contacted
+- Fixed issue allowing mods to be updated to incompatible versions
+- Fixed ModVersion CanBeUpdated property
+
+## [0.23.5]
+
+### Bugfixes
+
+- Fix loader update
+
+## [0.23.4]
+
+### Features
+- Reorganized UI (almost entirely cosmetic)
+- Icon added to builds and re-enabled
+- App startup window is now shown on top
+- Added Discord link
+- Aurora is backed up before updates
+- Previous 4 checkboxes ('Enable mods'/'Enable approved mods'/'Enable public mods'/'Enable poweruser mods') have been replaced with two: 'Enable mods' which enables the use of approved mods, and 'Enable poweruser mods' which enables the use of poweruser mods. Utilities like A4xCalc can be used regardless.
+
+### Bugfixes
+- Fixed old bug in the Reddit links
+- Fixed a case where the 'Update' button could be clicked when the selected mod was already up to date
+- Fixed several crashes related to unknown checksums / set to 1.0.0 as last resort
+
+## [0.23.1]
+
+### Features
+- Complete UI overhaul from AGM-114. No more tabs!
+- AuroraLoader now actually allows you to manage mods when you don't have an internet connection
+
+### Bugfixes
+- A litany of visible and invisible UI issues and poor practices
+- Loader no longer crashes when a `mod.ini` points to a bad or nonexistent config file
+- Loader no longer crashes if a mirror doesn't work / you're not connected to the internet
+- Modals for both of the above with actionable information
+- A 'mod download failed' modal to give the user some feedback when that happens (previously, it looked like something was happening)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,19 +4,21 @@
 
 ### Changes
 - `mod.json` and AuroraLoader now support changelog files (there's a Changelog button next to the Config File button in the mod manager now)
+- AuroraLoader now has a changelog as well, and there's a button for accessing it
 - Aurora version targeted by the currently loaded game is shown in parenthesis (and only mods compatible with the loaded game's version are shown - but that was already the case)
 - Additional message after updating Aurora telling user to create a new game in order to use the new version
 - Got rid of modal dialogs prompting user to update Aurora/the loader on launch (there are a lot of cases where people want to hang back at 1.9.5 and I don't want to annoy them - IMHO the snazzy new update icons are obvious enough). This also means that the dialogs aren't re-shown every time `RefreshInstallData()` is called.
 - Behavior when creating new save games is a bit more intuitive (the 'new game' button is disabled when it can't be clicked, and the user is presented with a confirmation dialog before creating a fresh DB that tells them the version of Aurora that the new game will target - in later Loader versions, we may allow them to select this manually)
-- (Devs) GitHub Action now builds the loader on the LTS version of .NET Core 3.1 and appends the built commit to the artifact's name
+- Selected executable mod is no longer reset after checking or unchecking 'Enable Poweruser Mods'
+- Lists of available mods are now updated after making changes in the Mod Manager window
+- (Devs) GitHub Action now builds the loader on the LTS version of .NET Core 3.1, produces a self-contained executable, and appends the built commit to the artifact's name
 
 ### Bugfixes
 - Buttons for opening a mod's config & changelog files are disabled if the mod hasn't actually been installed yet
 - Fixed typo in Aurora & loader update confirmation dialogs
 - Confirmation dialogs are now shown when the user decides to manually update either Aurora or the loader (previously behavior was inconsistent)
 - Removed an unused click handler & fixed some typos in the codebase
-
-[AuroraLoader-096cd.zip](https://github.com/Aurora-Modders/AuroraLoader/files/4693370/AuroraLoader-096cd.zip)
+- Mod manager is now modal
 
 ## [0.25.2]
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,23 @@
 
 ![](https://i.ibb.co/JxJhfyY/0-24-0.png)
 
+# Features
+
+- Discover and install mods from the [Aurora Registry](https://github.com/Aurora-Modders/AuroraRegistry)
+- Safely update Aurora
+- Manage multiple games that use different versions of Aurora
+- Access community resources and file bug reports
+- Play background music!
+
+## Details
+
+- Supports running Aurora with custom exe launchers, database modifications, and any launching number of utilities*
+- Automatically detects and installs updates to both Aurora and itself
+- Displays mods by type, version, Aurora version compatibility, and whether or not they've been approved by the developer
+- Supports externally-hosted mirrors other than the [Aurora Registry](https://github.com/Aurora-Modders/AuroraRegistry)
+- Validates mod structure and compatibility with your version of Aurora
+- Allows easy access to mod config and changelog files
+
 # Installation Requirements
 
 You must have the .NET Core 3.1 x86 runtime installed - download it [here](https://dotnet.microsoft.com/download/dotnet-core/thank-you/runtime-desktop-3.1.3-windows-x86-installer). This is a system-level prerequisite similar to a Java JRE or the dependency that Aurora itself has on the .NET Framework 4.0. We decided to publish a small executable that relies on this library rather than releasing a large (>60mb) executable without that dependency for convenience, but the latter can easily be created (let us know!).
@@ -10,18 +27,7 @@ Otherwise, there are no requirements to use or develop AuroraLoader - not even A
 
 # Usage
 
-Download the latest release and extract to a directory. Run the .exe. If the directory doesn't contain a copy of Aurora the latest version will be downloaded automatically. Mods in the online registry can be viewed, installed, upgraded, and configured on the 'Manage Mods' tab.
-
-# Features
-
-- Automatically installs, backs up, and updates both Aurora and itself
-- Browse mods on the Aurora Registry by type, version, and whether or not they've been approved by the developer
-- Validates mod structure and compatibility with your version of Aurora
-- Supports running Aurora with custom exe launchers, database modifications, and any launching number of utilities*
-- Supports configuring many mods
-- Adds optional in-game music
-
-*Using mods carries with it the risk of unintended behavior - we ask that you not submit bug reports to the developer when using mods outside of the 'Approved' category and make this clear in the UI.
+Download the latest release and extract to a directory. Run the .exe. If the directory doesn't contain a copy of Aurora the latest version of Aurora will be downloaded automatically. Mods in the online registry can be viewed, installed, upgraded, and configured on the 'Manage Mods' tab.
 
 # Support
 

--- a/README.md
+++ b/README.md
@@ -19,15 +19,15 @@
 - Validates mod structure and compatibility with your version of Aurora
 - Allows easy access to mod config and changelog files
 
-# Installation Requirements
+# Requirements
 
-You must have the .NET Core 3.1 x86 runtime installed - download it [here](https://dotnet.microsoft.com/download/dotnet-core/thank-you/runtime-desktop-3.1.3-windows-x86-installer). This is a system-level prerequisite similar to a Java JRE or the dependency that Aurora itself has on the .NET Framework 4.0. We decided to publish a small executable that relies on this library rather than releasing a large (>60mb) executable without that dependency for convenience, but the latter can easily be created (let us know!).
-
-Otherwise, there are no requirements to use or develop AuroraLoader - not even Aurora itself. In fact, extracting the AuroraLoader download zip into an empty folder is one of the most reliable ways to use it. Just download the latest release from the [Releases page](https://github.com/Aurora-Modders/AuroraLoader/releases) and run the executable. If you extract AuroraLoader to a directory that contains an existing Aurora installation, it will automatically be detected and backed up.
+You must have the [.NET Core 3.1 x86 runtime](https://dotnet.microsoft.com/download/dotnet-core/thank-you/runtime-desktop-3.1.4-windows-x86-installer) installed.
 
 # Usage
 
-Download the latest release and extract to a directory. Run the .exe. If the directory doesn't contain a copy of Aurora the latest version of Aurora will be downloaded automatically. Mods in the online registry can be viewed, installed, upgraded, and configured on the 'Manage Mods' tab.
+Download the [latest release](https://github.com/Aurora-Modders/AuroraLoader/releases) and extract AuroraLoader.zip to a new folder; it will automatically download a fresh copy of Aurora the first time it is run.
+
+If you'd like AuroraLoader to manage any of your existing games of Aurora, move the folders containing them (the entire Aurora installation!) into `<AuroraLoader install dir>/Games`. You'll be able to select those games from the interface, and AuroraLoader will make sure to load your games using the version of Aurora they're designed for even after you've updated to newer versions.
 
 # Support
 


### PR DESCRIPTION
## [0.25.3]

### Changes
- `mod.json` and AuroraLoader now support changelog files (there's a Changelog button next to the Config File button in the mod manager now)
- AuroraLoader now has a changelog as well, and there's a button for accessing it
- Aurora version targeted by the currently loaded game is shown in parenthesis (and only mods compatible with the loaded game's version are shown - but that was already the case)
- Additional message after updating Aurora telling user to create a new game in order to use the new version
- Got rid of modal dialogs prompting user to update Aurora/the loader on launch (there are a lot of cases where people want to hang back at 1.9.5 and I don't want to annoy them - IMHO the snazzy new update icons are obvious enough). This also means that the dialogs aren't re-shown every time `RefreshInstallData()` is called.
- Behavior when creating new save games is a bit more intuitive (the 'new game' button is disabled when it can't be clicked, and the user is presented with a confirmation dialog before creating a fresh DB that tells them the version of Aurora that the new game will target - in later Loader versions, we may allow them to select this manually)
- Selected executable mod is no longer reset after checking or unchecking 'Enable Poweruser Mods'
- Lists of available mods are now updated after making changes in the Mod Manager window

### Bugfixes
- Buttons for opening a mod's config & changelog files are disabled if the mod hasn't actually been installed yet
- Fixed typo in Aurora & loader update confirmation dialogs
- Confirmation dialogs are now shown when the user decides to manually update either Aurora or the loader (previously behavior was inconsistent)
- Removed an unused click handler & fixed some typos in the codebase
- Mod manager is now modal

### Builds
- Build action updated to build loader on the LTS version of .NET Core 3.1
- Build action produces a self-contained executable (i.e. the ~55mb executables typically updated with @01010100b's releases, and expected by the Loader's auto-update functionality). We are still working to debug a few reports of the loader not launching due to compatibility issues - please get in touch if you're experiencing issues!
- Commit SHA appended to name of artifact uploaded by build action

Release candidate download: https://github.com/Aurora-Modders/AuroraLoader/releases/tag/0.25.3-rc2