### PR TITLE
When the DownloadDir contains only a single directory, assume the mod is inside it

### DIFF
--- a/AuroraLoader/Mods/ModVersion.cs
+++ b/AuroraLoader/Mods/ModVersion.cs
@@ -36,7 +36,7 @@ namespace AuroraLoader.Mods
                 // if the DownloadPath contains only a single directory, use that directory instead
                 var dirs = Directory.EnumerateDirectories(DownloadPath).ToList();
                 if (dirs.Count == 1) {
-                    return files[0];
+                    return dirs[0];
                 } else {
                     return DownloadPath;
                 }

--- a/AuroraLoader/Mods/ModVersion.cs
+++ b/AuroraLoader/Mods/ModVersion.cs
@@ -31,7 +31,7 @@ namespace AuroraLoader.Mods
         public bool Downloaded => Directory.Exists(DownloadPath);
 
         [JsonIgnore]
-        public string ContentPath => {
+        public string ContentPath {
             get {
                 // if the DownloadPath contains only a single directory, use that directory instead
                 var dirs = Directory.EnumerateDirectories(DownloadPath).ToList();

--- a/AuroraLoader/Mods/ModVersion.cs
+++ b/AuroraLoader/Mods/ModVersion.cs
@@ -32,16 +32,16 @@ namespace AuroraLoader.Mods
 
         [JsonIgnore]
         public string ContentPath => {
-            var files = Directory.EnumerateFiles(DownloadPath).ToList();
-            if (files.Count == 1) {
-                FileAttributes attr = File.GetAttributes(files[0]);
-                if (attr.HasFlag(FileAttributes.Directory)) {
+            get {
+                // if the DownloadPath contains only a single directory, use that directory instead
+                var dirs = Directory.EnumerateDirectories(DownloadPath).ToList();
+                if (dirs.Count == 1) {
                     return files[0];
+                } else {
+                    return DownloadPath;
                 }
-            } else {
-                return DownloadPath;
             }
-        };
+        }
 
         [JsonIgnore]
         public Mod Mod { get; set; }

--- a/AuroraLoader/Mods/ModVersion.cs
+++ b/AuroraLoader/Mods/ModVersion.cs
@@ -31,6 +31,19 @@ namespace AuroraLoader.Mods
         public bool Downloaded => Directory.Exists(DownloadPath);
 
         [JsonIgnore]
+        public string ContentPath => {
+            var files = Directory.EnumerateFiles(DownloadPath).ToList();
+            if (files.Count == 1) {
+                FileAttributes attr = File.GetAttributes(files[0]);
+                if (attr.HasFlag(FileAttributes.Directory)) {
+                    return files[0];
+                }
+            } else {
+                return DownloadPath;
+            }
+        }
+
+        [JsonIgnore]
         public Mod Mod { get; set; }
 
 
@@ -118,7 +131,7 @@ namespace AuroraLoader.Mods
         {
             if (Mod.Type == ModType.UTILITY)
             {
-                return Run(DownloadPath, Mod.LaunchCommand);
+                return Run(ContentPath, Mod.LaunchCommand);
             }
             else if (Mod.Type == ModType.ROOTUTILITY || Mod.Type == ModType.EXECUTABLE)
             {
@@ -140,7 +153,7 @@ namespace AuroraLoader.Mods
                 var table = new SqliteCommand(TABLE, connection);
                 table.ExecuteNonQuery();
 
-                var files = Directory.EnumerateFiles(DownloadPath, "*.sql").ToList();
+                var files = Directory.EnumerateFiles(ContentPath, "*.sql").ToList();
                 try
                 {
                     var uninstall = files.Single(f => Path.GetFileName(f).Equals("uninstall.sql"));
@@ -175,10 +188,10 @@ namespace AuroraLoader.Mods
 
         private void UninstallDbMod(AuroraInstallation installation)
         {
-            var uninstallScript = Path.Combine(DownloadPath, "uninstall.sql");
+            var uninstallScript = Path.Combine(ContentPath, "uninstall.sql");
             if (!File.Exists(uninstallScript))
             {
-                throw new Exception($"Db mod {Mod.Name} uninstall.sql not found at {DownloadPath}");
+                throw new Exception($"Db mod {Mod.Name} uninstall.sql not found at {ContentPath}");
             }
 
             using (var connection = new SqliteConnection(installation.ConnectionString))
@@ -230,9 +243,9 @@ namespace AuroraLoader.Mods
 
         private void UninstallThemeMod(AuroraInstallation installation)
         {
-            foreach (var fileInMod in Directory.EnumerateFiles(DownloadPath, "*.*", SearchOption.AllDirectories))
+            foreach (var fileInMod in Directory.EnumerateFiles(ContentPath, "*.*", SearchOption.AllDirectories))
             {
-                var out_file = Path.Combine(installation.InstallationPath, Path.GetRelativePath(DownloadPath, fileInMod));
+                var out_file = Path.Combine(installation.InstallationPath, Path.GetRelativePath(ContentPath, fileInMod));
                 if (File.Exists(out_file))
                 {
                     File.Delete(out_file);

--- a/AuroraLoader/Mods/ModVersion.cs
+++ b/AuroraLoader/Mods/ModVersion.cs
@@ -41,7 +41,7 @@ namespace AuroraLoader.Mods
             } else {
                 return DownloadPath;
             }
-        }
+        };
 
         [JsonIgnore]
         public Mod Mod { get; set; }


### PR DESCRIPTION
Gracefully handles the case where all the mod's files are inside a
directory inside the zip file.

I've never written any C# before, and I don't have a compiler or development environment set up for it. @01010100b, could you check this over and see if it actually works?